### PR TITLE
Reset version to 0.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,24 +2,16 @@
 Changelog
 =========
 
-Version 1.0.0
-=============
+Version 0.1
+===========
+
+Features
+--------
 
 * Supports the Adonis and Valkmusa architectures.
 * Extends the OpenQASM language with gates native to the IQM architectures.
 * Loads quantum circuits from OpenQASM files.
-* Decomposes gates into the native gate set.
+* Decomposes gates into the native gate set of the chosen architecture.
 * Optimizes the circuit by merging neighboring gates, and commuting z rotations towards the end of the circuit.
-
-Version 1.1.0
-=============
-
-* Maps quantum circuits into qjobs-native gate sequences and executes them.
-* Bump dependencies to Python 3.8, Cirq 0.9.1.
-
-Version 1.2.0
-=============
-
-* Remove the qjobs dependency, the gate_mapper module, and the circuit execution functionality they provide.
-* `qsim <https://quantumai.google/qsim>`_ can be used to simulate the circuit in addition to the
-  standard Cirq simulators.
+* Circuits can be simulated using both the standard Cirq simulators and the
+  `qsim <https://quantumai.google/qsim>`_ simulators.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Cirq on IQM
 ###########
 
-`Google Cirq <https://github.com/quantumlib/Cirq>`_ descriptions of IQM's quantum architectures.
+`Google Cirq <https://github.com/quantumlib/Cirq>`_ adapter for IQM's quantum architectures.
 
 
 What is it good for?

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.mathjax',
     'sphinx.ext.todo',
+    'sphinx.ext.extlinks',
     'sphinx_automodapi.automodapi',
 ]
 
@@ -102,6 +103,14 @@ mathjax_config = {
             'iprod': [r'\left\langle #1 | #2 \right\rangle', 2],  # two arguments
         }
     }
+}
+
+
+# -- External mapping ------------------------------------------------------------
+
+extlinks = {
+    'issue': ('https://github.com/iqm-finland/cirq-on-iqm/issues/%s', 'issue '),
+    'mr': ('https://github.com/iqm-finland/cirq-on-iqm/pull/%s', 'MR '),
 }
 
 


### PR DESCRIPTION
* The package name has changed to `cirq-iqm`, so we also reset the version history.
* CHANGELOG items should from now on have links to pull requests that implement the feature or fix the bug, done using a `sphinx.ext.extlinks` RST role.