### PR TITLE
Adonis gateset updated. CZ-targeting decompositions added.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,10 +10,13 @@ Features
 --------
 
 * Adonis native gate set updated, CZ-targeting decompositions added. :mr:`15`
+* Circuits can be sent to be executed remotely on IQM hardware. :mr:`13`
 
 
 Version 0.1
 ===========
+
+Released 2021-04-21
 
 Features
 --------
@@ -25,12 +28,3 @@ Features
 * Optimizes the circuit by merging neighboring gates, and commuting z rotations towards the end of the circuit.
 * Circuits can be simulated using both the standard Cirq simulators and the
   `qsim <https://quantumai.google/qsim>`_ simulators.
-
-
-Version 0.2
-===========
-
-Features
---------
-
-* Circuits can be sent to be executed remotely

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog
 =========
 
+
+Version 0.2
+===========
+
+Features
+--------
+
+* Adonis native gate set updated, CZ-targeting decompositions added. :mr:`15`
+
+
 Version 0.1
 ===========
 

--- a/src/cirq_iqm/adonis.py
+++ b/src/cirq_iqm/adonis.py
@@ -14,6 +14,11 @@
 """
 IQM's Adonis quantum architecture.
 """
+from __future__ import annotations
+
+from typing import Optional
+
+import cirq
 from cirq import ops
 
 import cirq_iqm.iqm_device as idev
@@ -62,7 +67,7 @@ class Adonis(idev.IQMDevice):
         ops.CZPowGate(),
     )
 
-    def operation_decomposer(self, op):
+    def operation_decomposer(self, op: cirq.Operation) -> Optional[list[cirq.Operation]]:
         """Decomposes gates into the native Adonis gate set.
         """
         # NOTE: All the decompositions below keep track of global phase (required for decomposing

--- a/src/cirq_iqm/adonis.py
+++ b/src/cirq_iqm/adonis.py
@@ -72,13 +72,18 @@ class Adonis(idev.IQMDevice):
         if isinstance(op.gate, ops.ISwapPowGate):
             # the ISwap family is implemented using the XY interaction
             s = -0.5 * op.gate.exponent
-            return [ig.XYGate(exponent=s).on(*op.qubits)]
+            return [
+                ig.XYGate(exponent=s).on(*op.qubits)
+            ]
         if isinstance(op.gate, ops.CZPowGate):
             # decompose CZPowGate using IsingGate
             s = -0.5 * op.gate.exponent
-            G = ig.IsingGate(exponent=s, global_shift=-0.5)
             L = ops.ZPowGate(exponent=-s, global_shift=-0.5)
-            return [G.on(*op.qubits), L.on(op.qubits[0]), L.on(op.qubits[1])]
+            return [
+                ig.IsingGate(exponent=s, global_shift=-0.5).on(*op.qubits),
+                L.on(op.qubits[0]),
+                L.on(op.qubits[1]),
+            ]
         if isinstance(op.gate, ig.IsingGate):
             # decompose IsingGate using two CZs
             s = op.gate.exponent

--- a/src/cirq_iqm/iqm_device.py
+++ b/src/cirq_iqm/iqm_device.py
@@ -17,9 +17,9 @@ Describes IQM quantum architectures in the Cirq framework.
 The description includes the qubit connectivity, the native gate set, and the gate decompositions
 and circuit optimization methods to use with the architecture.
 """
+# pylint: disable=protected-access
 from __future__ import annotations
 
-# pylint: disable=protected-access
 import abc
 import collections
 import collections.abc as ca
@@ -301,7 +301,12 @@ class MergeOneParameterGroupGates(circuits.PointOptimizer):
     """
     one_parameter_families = (ig.XYGate, ig.IsingGate)
 
-    def optimization_at(self, circuit, index, op):
+    def optimization_at(
+            self,
+            circuit: cirq.Circuit,
+            index: int,
+            op: cirq.Operation,
+    ) -> Optional[cirq.PointOptimizationSummary]:
         if not isinstance(op.gate, self.one_parameter_families):
             return None
 
@@ -368,7 +373,7 @@ class IQMEjectZ(optimizers.EjectZ):
 
         return False
 
-    def optimize_circuit(self, circuit: circuits.Circuit):
+    def optimize_circuit(self, circuit: circuits.Circuit) -> None:
         # pylint: disable=too-many-locals
         # Tracks qubit phases (in half turns; multiply by pi to get radians).
         qubit_phase: dict[cirq.ops.Qid, float] = collections.defaultdict(lambda: 0)
@@ -437,7 +442,12 @@ class DropRZBeforeMeasurement(circuits.PointOptimizer):
 
     These z rotations do not affect the result of the measurement, so we may ignore them.
     """
-    def optimization_at(self, circuit, index, op):
+    def optimization_at(
+            self,
+            circuit: cirq.Circuit,
+            index: int,
+            op: cirq.Operation,
+    ) -> Optional[cirq.PointOptimizationSummary]:
 
         def find_removable_rz() -> list[int]:
             """Finds z rotations that can be removed.
@@ -472,7 +482,12 @@ class DropRZBeforeMeasurement(circuits.PointOptimizer):
 class DecomposeGatesFinal(circuits.PointOptimizer):
     """Decomposes gates during the final decomposition round.
     """
-    def optimization_at(self, circuit, index, op):
+    def optimization_at(
+            self,
+            circuit: cirq.Circuit,
+            index: int,
+            op: cirq.Operation,
+    ) -> Optional[cirq.PointOptimizationSummary]:
         if not isinstance(op.gate, circuit.device.DECOMPOSE_FINALLY):
             return None  # no changes
 

--- a/tests/iqm_gates_test.py
+++ b/tests/iqm_gates_test.py
@@ -29,10 +29,16 @@ class TestGates:
     def test_gate_matrices_ising(self, t):
         """Verify that the Ising gates work as expected."""
 
-        CZ = cirq.CZPowGate(exponent=t)._unitary_()
-        s = 1 - t / 2
+        G = cirq.CZPowGate(exponent=t)._unitary_()
+        s = -t / 2
         L = cirq.rz(-np.pi * s)._unitary_()
-        assert np.allclose(np.exp(-1j * np.pi / 2 * s) * np.kron(L, L) @ ig.IsingGate(exponent=s)._unitary_(), CZ)
+        U = np.exp(-1j * np.pi / 2 * s) * np.kron(L, L) @ ig.IsingGate(exponent=s)._unitary_()
+        assert np.allclose(U, G)
+
+        L = cirq.ZPowGate(exponent=-s)._unitary_()
+        U = np.exp(1j * np.pi / 2 * s) * np.kron(L, L) @ ig.IsingGate(exponent=s)._unitary_()
+        assert np.allclose(U, G)
+
 
     @pytest.mark.parametrize('t', [1.83, 0.5, -0.5])
     def test_gate_matrices_xy(self, t):


### PR DESCRIPTION
* Adonis gateset update: CZ is the only native two-qubit gate for now.
* Added decompositions targeting CZ.
* Cleaning up type annotations.