### PR TITLE
enhance the handling of qubit_mapping

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ What is it good for?
 
 Currently Cirq on IQM can
 
-* take an arbitrary quantum circuit created in Cirq or load from an OpenQASM 2.0 file
+* take an arbitrary quantum circuit created using Cirq or imported from an OpenQASM 2.0 file
 * map the circuit into an equivalent one compatible with the chosen IQM quantum architecture
 * optimize the circuit by commuting and merging gates
 * simulate the circuit using one of Cirq's simulators
@@ -57,7 +57,7 @@ Run the demo:
    $ python cirq-on-iqm/examples/demo_adonis.py
 
 
-Run code on a real quantum computer:
+Execute a quantum circuit on an IQM quantum computer:
 
 .. code-block:: bash
 

--- a/src/cirq_iqm/adonis.py
+++ b/src/cirq_iqm/adonis.py
@@ -54,6 +54,8 @@ class Adonis(idev.IQMDevice):
     The qubits can be measured simultaneously or separately once, at the end of the circuit.
     """
 
+    QUBIT_COUNT = 5
+
     CONNECTIVITY = ({1, 3}, {2, 3}, {4, 3}, {5, 3})
 
     # Subject to change

--- a/src/cirq_iqm/iqm_device.py
+++ b/src/cirq_iqm/iqm_device.py
@@ -122,7 +122,7 @@ class IQMDevice(devices.Device):
             # map based on numeric identifier in the qubit name
             idx = re.search(r'\D*(\d+)?\D*', qubit.name).group(1)
             if idx is None:
-                raise ValueError('Qubit names do not contain numbering')
+                raise ValueError('Qubit names must contain a number.')
             return self.qubits[int(idx) - 1]
 
         def map_op(op: cirq.Operation) -> cirq.Operation:

--- a/src/cirq_iqm/iqm_device.py
+++ b/src/cirq_iqm/iqm_device.py
@@ -54,7 +54,7 @@ class IQMDevice(devices.Device):
     """number of qubits on the device"""
 
     QUBIT_NAME_PREFIX: str = 'QB'
-    """prefix for naming qubits based on their numerical index"""
+    """prefix for qubit names, to be followed by their numerical index"""
 
     CONNECTIVITY: tuple[set[int]] = ()
     """qubit connectivity graph of the device"""

--- a/src/cirq_iqm/iqm_device.py
+++ b/src/cirq_iqm/iqm_device.py
@@ -51,7 +51,7 @@ class IQMDevice(devices.Device):
     optimizing circuits and mapping qubits.
     """
     QUBIT_COUNT: int = None
-    """the number of qubits in the device"""
+    """number of qubits on the device"""
 
     QUBIT_NAME_PREFIX: str = 'QB'
     """prefix for naming qubits based on their numerical index"""

--- a/src/cirq_iqm/iqm_device.py
+++ b/src/cirq_iqm/iqm_device.py
@@ -115,7 +115,7 @@ class IQMDevice(devices.Device):
         # TODO permute circuit qubits to try to satisfy the device connectivity
         def map_qubit(qubit: cirq.ops.Qid) -> cirq.ops.Qid:
             if not isinstance(qubit, cirq.NamedQubit):
-                raise ValueError('Only qubits of type cirq.NamedQubit are supported')
+                raise ValueError('Only qubits of type cirq.NamedQubit are supported.')
             if qubit in self.qubits:
                 return qubit
 

--- a/src/cirq_iqm/iqm_device.py
+++ b/src/cirq_iqm/iqm_device.py
@@ -32,23 +32,6 @@ from cirq import circuits, devices, ops, optimizers, protocols
 
 GATE_MERGING_TOLERANCE = 1e-10
 
-
-class IQMQubit(cirq.NamedQubit):
-    """NamedQubit that also has a unique integer index.
-
-    Currently the name always depends on the index.
-
-    Args:
-        index: qubit index
-    """
-    def __init__(self, index: int):
-        super().__init__('QB{}'.format(index))
-        self.index = index
-
-    def __repr__(self):
-        return 'IQMQubit({})'.format(self.index)
-
-
 def _verify_unique_measurement_keys(operations: ca.Iterable[cirq.Operation]) -> None:
     """Raises an error if a measurement key is repeated in the given set of Operations.
     """
@@ -67,6 +50,11 @@ class IQMDevice(devices.Device):
     Adds extra functionality on top of the basic :class:`cirq.Device` class for decomposing gates,
     optimizing circuits and mapping qubits.
     """
+    QUBIT_COUNT: int = None
+    """the number of qubits in the device"""
+
+    QUBIT_NAME_PREFIX: str = 'QB'
+    """prefix for naming qubits based on their numerical index"""
 
     CONNECTIVITY: tuple[set[int]] = ()
     """qubit connectivity graph of the device"""
@@ -82,18 +70,12 @@ class IQMDevice(devices.Device):
     (we decompose them later, during the final circuit optimization stage)"""
 
     def __init__(self):
-        # qubit set (assumes no unconnected qubits)
-        qubits = {q for c in self.CONNECTIVITY for q in c}
-        bad = {q for q in qubits if q < 1}
-        if bad:
-            raise ValueError('{} connectivity map: the qubit numbers {} are < 1.'.format(self.__class__.__name__, bad))
+        self.qubits = tuple(cirq.NamedQubit.range(1, self.QUBIT_COUNT + 1, prefix=self.QUBIT_NAME_PREFIX))
 
-        expected = range(1, max(qubits) + 1)
-        missing = sorted(set(expected) - qubits)
-        if missing:
-            raise ValueError('{} connectivity map: the qubits {} are missing.'.format(self.__class__.__name__, missing))
-
-        self.qubits = tuple(IQMQubit(k) for k in expected)
+    @classmethod
+    def get_qubit_index(cls, qubit: cirq.NamedQubit):
+        """return the numeric index of the given qubit on device"""
+        return int(qubit.name[len(cls.QUBIT_NAME_PREFIX):])
 
     @classmethod
     def is_native_operation(cls, op: cirq.Operation) -> bool:
@@ -132,11 +114,16 @@ class IQMDevice(devices.Device):
         """
         # TODO permute circuit qubits to try to satisfy the device connectivity
         def map_qubit(qubit: cirq.ops.Qid) -> cirq.ops.Qid:
-            """NamedQubits are mapped to device qubits, other types of qubits are passed through as is."""
-            if isinstance(qubit, cirq.NamedQubit):
-                idx = int(re.search(r'\D*(\d+)?\D*', qubit.name).group(1))
-                return self.qubits[idx - 1]
-            return qubit
+            if not isinstance(qubit, cirq.NamedQubit):
+                raise ValueError('Only qubits of type cirq.NamedQubit are supported')
+            if qubit in self.qubits:
+                return qubit
+
+            # map based on numeric identifier in the qubit name
+            idx = re.search(r'\D*(\d+)?\D*', qubit.name).group(1)
+            if idx is None:
+                raise ValueError('Qubit names do not contain numbering')
+            return self.qubits[int(idx) - 1]
 
         def map_op(op: cirq.Operation) -> cirq.Operation:
             """Replaces the qubits the gate is acting on with corresponding device qubits."""
@@ -280,7 +267,7 @@ class IQMDevice(devices.Device):
         """Raises a ValueError if operation acts on qubits that are not connected.
         """
         if len(operation.qubits) >= 2 and not isinstance(operation.gate, ops.MeasurementGate):
-            connection = set(q.index for q in operation.qubits)
+            connection = set(cls.get_qubit_index(q) for q in operation.qubits)
             if connection not in cls.CONNECTIVITY:
                 raise ValueError('Unsupported qubit connectivity required for {!r}'.format(operation))
 

--- a/src/cirq_iqm/iqm_device.py
+++ b/src/cirq_iqm/iqm_device.py
@@ -74,7 +74,7 @@ class IQMDevice(devices.Device):
 
     @classmethod
     def get_qubit_index(cls, qubit: cirq.NamedQubit) -> int:
-        """return the numeric index of the given qubit on device"""
+        """The numeric index of the given qubit on the device."""
         return int(qubit.name[len(cls.QUBIT_NAME_PREFIX):])
 
     @classmethod

--- a/src/cirq_iqm/iqm_device.py
+++ b/src/cirq_iqm/iqm_device.py
@@ -73,7 +73,7 @@ class IQMDevice(devices.Device):
         self.qubits = tuple(cirq.NamedQubit.range(1, self.QUBIT_COUNT + 1, prefix=self.QUBIT_NAME_PREFIX))
 
     @classmethod
-    def get_qubit_index(cls, qubit: cirq.NamedQubit):
+    def get_qubit_index(cls, qubit: cirq.NamedQubit) -> int:
         """return the numeric index of the given qubit on device"""
         return int(qubit.name[len(cls.QUBIT_NAME_PREFIX):])
 

--- a/src/cirq_iqm/iqm_operation_mapping.py
+++ b/src/cirq_iqm/iqm_operation_mapping.py
@@ -75,6 +75,6 @@ def map_operation(operation: Operation) -> InstructionDTO:
                 qubits=qubits,
                 args={}
             )
-        raise OperationNotSupportedError(f'CZPowGate exponent was {operation.gate.exponent}, can only be 1.')
+        raise OperationNotSupportedError(f'CZPowGate exponent {operation.gate.exponent}, only 1 is natively supported.')
 
-    raise OperationNotSupportedError(f'{type(operation)} not natively supported.')
+    raise OperationNotSupportedError(f'{type(operation.gate)} not natively supported.')

--- a/src/cirq_iqm/iqm_remote.py
+++ b/src/cirq_iqm/iqm_remote.py
@@ -23,11 +23,12 @@ import cirq
 import numpy as np
 from cirq import study
 from cirq.study import resolver
+from cirq_iqm import IQMDevice
 from cirq_iqm.iqm_client import CircuitDTO, IQMClient, SingleQubitMappingDTO
 from cirq_iqm.iqm_operation_mapping import map_operation
 
 
-def _serialize_iqm(circuit: cirq.Circuit) -> CircuitDTO:
+def _serialize_circuit(circuit: cirq.Circuit) -> CircuitDTO:
     """Serializes a quantum circuit into the IQM data transfer format.
 
     Args:
@@ -48,6 +49,11 @@ def _serialize_iqm(circuit: cirq.Circuit) -> CircuitDTO:
     )
 
 
+def _serialize_qubit_mapping(qubit_mapping: dict[str, str]):
+    """Serializes a qubit mapping dict into the corresponding IQM data transfer format"""
+    return [SingleQubitMappingDTO(logical_name=k, physical_name=v) for k, v in qubit_mapping.items()]
+
+
 class IQMSampler(cirq.work.Sampler):
     """Circuit sampler for executing quantum circuits on IQM quantum computers.
 
@@ -56,9 +62,24 @@ class IQMSampler(cirq.work.Sampler):
         settings: Settings for the quantum computer.
         qubit_mapping: A dict that maps logical qubit names to physical qubit names
     """
-    def __init__(self, url: str, settings: str, qubit_mapping: dict[str, str]):
-        self._client = IQMClient(url, settings=json.loads(settings))
-        self._qubit_mapping = [SingleQubitMappingDTO(logical_name=k, physical_name=v) for k, v in qubit_mapping.items()]
+    def __init__(self, url: str, settings: str, device: IQMDevice, qubit_mapping: dict[str, str] = None):
+        settings_json = json.loads(settings)
+
+        if not qubit_mapping:
+            # If qubit_mapping empty or None create identity mapping
+            qubit_mapping = {qubit.name: qubit.name for qubit in device.qubits}
+        else:
+            # verify that the given qubit_mapping is injective
+            if not len(set(qubit_mapping.values())) == len(qubit_mapping.values()):
+                raise ValueError('Multiple logical qubits map to the same physical qubit')
+
+        # verify that all target qubits in qubit_mapping are defined in the settings
+        if not all(qubit in settings_json['subtrees'] for qubit in qubit_mapping.values()):
+            raise ValueError('One or more qubits do not have matching definition in the settings')
+
+        self._client = IQMClient(url, settings=settings_json)
+        self._device = device
+        self._qubit_mapping = qubit_mapping
 
     def run_sweep(
             self,
@@ -80,9 +101,19 @@ class IQMSampler(cirq.work.Sampler):
         Raises:
             NotImplementedError: user tried to run a nontrivial sweep
         """
+
         sweeps = study.to_sweeps(params or study.ParamResolver({}))
         if len(sweeps) > 1 or len(sweeps[0].keys) > 0:
             raise NotImplementedError('Sweeps are not supported')
+
+        if program.device is cirq.UNCONSTRAINED_DEVICE:
+            # verify that qubit_mapping covers all qubits in the circuit
+            circuit_qubits = set(qubit.name for qubit in program.all_qubits())
+            if not circuit_qubits.issubset(set(self._qubit_mapping.keys())):
+                raise ValueError('Provided qubit_mapping does not cover all qubits in the circuit')
+        elif program.device != self._device:
+            raise ValueError('The devices of the given circuit and of the sampler are not the same')
+
         results = [self._send_circuit(program, repetitions=repetitions)]
         return results
 
@@ -104,8 +135,10 @@ class IQMSampler(cirq.work.Sampler):
             CircuitExecutionError: something went wrong on the server
             APITimeoutError: server did not return the results in the allocated time
         """
-        iqm_circuit = _serialize_iqm(circuit)
-        job_id = self._client.submit_circuit(iqm_circuit, self._qubit_mapping, repetitions)
+        iqm_circuit = _serialize_circuit(circuit)
+        qubit_mapping = _serialize_qubit_mapping(self._qubit_mapping)
+
+        job_id = self._client.submit_circuit(iqm_circuit, qubit_mapping, repetitions)
         results = self._client.wait_for_results(job_id)
         measurements = {k: np.array(v) for k, v in results.measurements.items()}
         return study.Result(params=resolver.ParamResolver(), measurements=measurements)

--- a/src/cirq_iqm/iqm_remote.py
+++ b/src/cirq_iqm/iqm_remote.py
@@ -28,7 +28,7 @@ from cirq_iqm.iqm_client import CircuitDTO, IQMClient, SingleQubitMappingDTO
 from cirq_iqm.iqm_operation_mapping import map_operation
 
 
-def _serialize_circuit(circuit: cirq.Circuit) -> CircuitDTO:
+def serialize_circuit(circuit: cirq.Circuit) -> CircuitDTO:
     """Serializes a quantum circuit into the IQM data transfer format.
 
     Args:
@@ -49,7 +49,7 @@ def _serialize_circuit(circuit: cirq.Circuit) -> CircuitDTO:
     )
 
 
-def _serialize_qubit_mapping(qubit_mapping: dict[str, str]) -> list[SingleQubitMappingDTO]:
+def serialize_qubit_mapping(qubit_mapping: dict[str, str]) -> list[SingleQubitMappingDTO]:
     """Serializes a qubit mapping dict into the corresponding IQM data transfer format.
 
     Args:
@@ -143,8 +143,8 @@ class IQMSampler(cirq.work.Sampler):
             CircuitExecutionError: something went wrong on the server
             APITimeoutError: server did not return the results in the allocated time
         """
-        iqm_circuit = _serialize_circuit(circuit)
-        qubit_mapping = _serialize_qubit_mapping(self._qubit_mapping)
+        iqm_circuit = serialize_circuit(circuit)
+        qubit_mapping = serialize_qubit_mapping(self._qubit_mapping)
 
         job_id = self._client.submit_circuit(iqm_circuit, qubit_mapping, repetitions)
         results = self._client.wait_for_results(job_id)

--- a/src/cirq_iqm/valkmusa.py
+++ b/src/cirq_iqm/valkmusa.py
@@ -44,6 +44,8 @@ class Valkmusa(idev.IQMDevice):
     The qubits are always measured simultaneously at the end of the computation.
     """
 
+    QUBIT_COUNT = 2
+
     CONNECTIVITY = ({1, 2},)
 
     NATIVE_GATES = (

--- a/tests/iqm_operation_mapping_test.py
+++ b/tests/iqm_operation_mapping_test.py
@@ -11,22 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import cirq
 import pytest
 from cirq import ZPowGate, GateOperation, MeasurementGate, CZPowGate, XPowGate, YPowGate, PhasedXPowGate
 from cirq_iqm.iqm_client import InstructionDTO
-from cirq_iqm.iqm_device import IQMQubit
 from cirq_iqm.iqm_operation_mapping import OperationNotSupportedError, map_operation
 
 
 @pytest.fixture()
-def qubit_1() -> IQMQubit:
-    return IQMQubit(1)
+def qubit_1() -> cirq.NamedQubit:
+    return cirq.NamedQubit('QB1')
 
 
 @pytest.fixture()
-def qubit_2() -> IQMQubit:
-    return IQMQubit(2)
+def qubit_2() -> cirq.NamedQubit:
+    return cirq.NamedQubit('QB2')
 
 
 def test_raises_error_for_unsupported_operation(qubit_1):

--- a/tests/iqm_remote_test.py
+++ b/tests/iqm_remote_test.py
@@ -74,13 +74,16 @@ def test_non_injective_qubit_mapping(base_url, settings_dict, qubit_mapping):
 
 def test_qubits_not_in_settings(circuit, base_url, settings_dict, qubit_mapping):
     del settings_dict['subtrees']['QB1']
-    with pytest.raises(ValueError, match='qubits do not have matching definition in the settings'):
+    with pytest.raises(
+            ValueError,
+            match="The physical qubits {'QB1'} in the qubit mapping are not defined in the settings"
+    ):
         IQMSampler(base_url, json.dumps(settings_dict), Adonis(), qubit_mapping)
 
 
 def test_incomplete_qubit_mapping(adonis_sampler, circuit):
-    new_qubit = cirq.NamedQubit('new qubit')
+    new_qubit = cirq.NamedQubit('Eve')
     circuit.append(cirq.X(new_qubit))
 
-    with pytest.raises(ValueError, match='does not cover all qubits in the circuit'):
+    with pytest.raises(ValueError, match="The qubits {'Eve'} are not found in the provided qubit mapping"):
         adonis_sampler.run(circuit)

--- a/tests/iqm_remote_test.py
+++ b/tests/iqm_remote_test.py
@@ -19,7 +19,7 @@ import pytest
 import cirq
 
 from cirq_iqm.iqm_client import SingleQubitMappingDTO
-from cirq_iqm.iqm_remote import IQMSampler, _serialize_qubit_mapping
+from cirq_iqm.iqm_remote import IQMSampler, serialize_qubit_mapping
 from cirq_iqm import Adonis
 from cirq_iqm.valkmusa import Valkmusa
 
@@ -47,7 +47,7 @@ def adonis_sampler(base_url, settings_dict, qubit_mapping):
 
 
 def test_serialize_qubit_mapping(qubit_mapping):
-    assert _serialize_qubit_mapping(qubit_mapping) == [
+    assert serialize_qubit_mapping(qubit_mapping) == [
         SingleQubitMappingDTO(logical_name='q1 log.', physical_name='QB1'),
         SingleQubitMappingDTO(logical_name='q2 log.', physical_name='QB2'),
     ]

--- a/tests/settings.json
+++ b/tests/settings.json
@@ -2,6 +2,10 @@
     "name": "root",
     "settings": {},
     "subtrees": {
-
+        "QB1": {},
+        "QB2": {},
+        "QB3": {},
+        "QB4": {},
+        "QB5": {}
     }
 }

--- a/tests/test_qubit_mapping.py
+++ b/tests/test_qubit_mapping.py
@@ -20,7 +20,6 @@ import cirq
 import pytest
 
 import cirq_iqm.adonis as ad
-from cirq_iqm.iqm_device import IQMQubit
 
 
 @pytest.fixture(scope='module')
@@ -63,7 +62,7 @@ class TestQubitMapping:
         # the mapped circuit is attached to the given device
         assert mapped.device is adonis
         # qubits have been mapped to device qubits
-        assert mapped[0].qubits == {IQMQubit(2)}
+        assert mapped[0].qubits == {cirq.NamedQubit('QB2')}
 
 
     def test_named_qubit_not_on_device(self, adonis):

--- a/tests/valkmusa_test.py
+++ b/tests/valkmusa_test.py
@@ -125,7 +125,6 @@ class TestOperationValidation:
 
     @pytest.mark.parametrize('qubit', [
         cirq.NamedQubit('xxx'),
-        cirq.NamedQubit('QB1'),  # name ok, but not a device qubit
     ])
     def test_qubits_not_on_device(self, valkmusa, qubit):
         """Gates operating on qubits not on device must not pass validation."""


### PR DESCRIPTION
- Remove `IQMQubit` class and use `cirq.NameQubit` instead
- Automatically generate identity qubit mapping (using device qubit names) when not provided by the end user
- Add relevant tests

COMP-118