### PR TITLE
Fix various Rz issues.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,15 +3,31 @@ Changelog
 =========
 
 
-Version 1.1 (2021-08-13)
+Version 1.2 (in progress)
 =========================
+
+Features
+--------
+
+* Adonis native gate set updated, Rz is not native.
+  `#41 <https://github.com/iqm-finland/cirq-on-iqm/pull/41>`_
+
+Bugfixes
+--------
+
+* DropRZMeasurements sometimes did not remove z rotations it should have.
+  `#41 <https://github.com/iqm-finland/cirq-on-iqm/pull/41>`_
+
+
+Version 1.1 (2021-08-13)
+========================
 
 * The version of ``requests`` dependency is relaxed.
 * Minor aesthetic changes in the documentation.
 
 
 Version 1.0 (2021-08-11)
-=========================
+========================
 
 Features
 --------

--- a/examples/demo_common.py
+++ b/examples/demo_common.py
@@ -66,7 +66,7 @@ def demo(
     print()
 
     # clean up the circuit (in place)
-    device.simplify_circuit(circuit_transformed)
+    circuit_transformed = device.simplify_circuit(circuit_transformed)
     print('Simplified circuit:')
     print(circuit_transformed)
     print()

--- a/src/cirq_iqm/adonis.py
+++ b/src/cirq_iqm/adonis.py
@@ -63,13 +63,28 @@ class Adonis(idev.IQMDevice):
         ops.PhasedXPowGate,
         ops.XPowGate,
         ops.YPowGate,
-        ops.ZPowGate,
         ops.MeasurementGate
     )
 
     NATIVE_GATE_INSTANCES = (
         ops.CZPowGate(),
     )
+
+    # We postpone the decomposition of the z rotations until the final stage of optimization,
+    # since usually they are eliminated by the EjectZ/DropRZBeforeMeasurement optimization stages.
+    DECOMPOSE_FINALLY = (ops.ZPowGate,)
+
+    def operation_final_decomposer(self, op: ops.Operation) -> Optional[list[cirq.Operation]]:
+        # Decomposes z rotations using x and y rotations.
+        if isinstance(op.gate, ops.ZPowGate):
+            # Rz using Rx, Ry
+            q = op.qubits[0]
+            return [
+                ops.XPowGate(exponent=-0.5).on(q),
+                ops.YPowGate(exponent=op.gate.exponent).on(q),
+                ops.XPowGate(exponent=0.5).on(q),
+            ]
+        raise NotImplementedError(f'Decomposition missing: {op.gate}')
 
     def operation_decomposer(self, op: cirq.Operation) -> Optional[list[cirq.Operation]]:
         # Decomposes gates into the native Adonis gate set.

--- a/src/cirq_iqm/iqm_device.py
+++ b/src/cirq_iqm/iqm_device.py
@@ -226,7 +226,7 @@ class IQMDevice(devices.Device):
         )
         return cirq.Circuit(moments)
 
-    def simplify_circuit(self, circuit: cirq.Circuit, max_iterations: int = 20) -> None:
+    def simplify_circuit(self, circuit: cirq.Circuit, max_iterations: int = 20) -> cirq.Circuit:
         """Simplifies and optimizes the given circuit.
 
         Currently it

--- a/src/cirq_iqm/valkmusa.py
+++ b/src/cirq_iqm/valkmusa.py
@@ -15,6 +15,7 @@
 IQM's Valkmusa quantum architecture.
 """
 from math import pi as PI
+from typing import Optional
 
 from cirq import ops
 
@@ -61,7 +62,7 @@ class Valkmusa(idev.IQMDevice):
     # we postpone the decomposition of the z rotations until the final stage of optimization
     DECOMPOSE_FINALLY = (ops.ZPowGate,)
 
-    def operation_final_decomposer(self, op: ops.Operation):
+    def operation_final_decomposer(self, op: ops.Operation) -> Optional[list[ops.Operation]]:
         # Decomposes z rotations using x and y rotations.
         if isinstance(op.gate, ops.ZPowGate):
             # Rz using Rx, Ry
@@ -71,9 +72,9 @@ class Valkmusa(idev.IQMDevice):
                 ops.YPowGate(exponent=op.gate.exponent).on(q),
                 ops.XPowGate(exponent=0.5).on(q),
             ]
-        raise NotImplementedError('Decomposition missing: {}'.format(op.gate))
+        raise NotImplementedError(f'Decomposition missing: {op.gate}')
 
-    def operation_decomposer(self, op: ops.Operation):
+    def operation_decomposer(self, op: ops.Operation) -> Optional[list[ops.Operation]]:
         # Decomposes CNOT and the CZPowGate family to Valkmusa native gates.
         # All the decompositions below keep track of global phase (required for decomposing controlled gates).
 

--- a/tests/test_adonis.py
+++ b/tests/test_adonis.py
@@ -52,11 +52,12 @@ native_1q_gates = [
     cirq.XPowGate(exponent=0.23),
     cirq.YPowGate(exponent=0.71),
     cirq.PhasedXPowGate(phase_exponent=1.7, exponent=-0.58),
+]
+
+finally_decomposed_1q_gates = [
     cirq.Z,
     cirq.ZPowGate(exponent=-0.23),
 ]
-
-finally_decomposed_1q_gates = []
 
 native_2q_gates = [
     cirq.CZ,
@@ -89,6 +90,14 @@ class TestOperationValidation:
 
         adonis.validate_operation(gate(adonis.qubits[q]))
         adonis.validate_operation(gate(adonis.qubits[q]).with_tags('tag_foo'))
+
+    @pytest.mark.parametrize('gate', finally_decomposed_1q_gates)
+    def test_finally_decomposed_single_qubit_gates(self, adonis, gate):
+        """Finally decomposed operations must pass validation."""
+
+        q0, q1 = adonis.qubits[:2]
+        adonis.validate_operation(gate(q0))
+        adonis.validate_operation(gate(q1).with_tags('tag_foo'))
 
     @pytest.mark.parametrize('gate', native_2q_gates)
     def test_native_two_qubit_gates(self, adonis, gate):

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -173,6 +173,26 @@ class TestSimplifyCircuit:
         assert isinstance(op.gate, cirq.ZPowGate)
         assert op.qubits == (q2,)
 
+    def test_drop_rz_before_measurement_drop_final(self, adonis):
+
+        q0, q1, q2 = adonis.qubits[:3]
+        c = cirq.Circuit()
+        c.append([
+            (cirq.X ** 0.4)(q0),
+            cirq.ZPowGate(exponent=0.1)(q1),  # Rz followed by measurement
+            cirq.MeasurementGate(1, key='measurement')(q1),
+            cirq.ZPowGate(exponent=0.2)(q2),  # final Rz
+        ])
+        new = c.copy()
+        DropRZBeforeMeasurement(drop_final=True).optimize_circuit(new)
+
+        assert len(new) == 2  # still 2 Moments
+        # both ZPowGates were dropped
+        assert len(tuple(new.all_operations())) == 2
+        op = new[0].operations[0]
+        assert isinstance(op.gate, cirq.XPowGate)
+        assert op.qubits == (q0,)
+
     def test_simplify_circuit_merge_one_qubit_gates(self, adonis):
 
         q0 = adonis.qubits[0]


### PR DESCRIPTION
* `Adonis` native gate set updated. Rz is no longer considered native.
* `DropRZBeforeMeasurement` can now also drop final Rz gates if required.
* Bugfix: `DropRZBeforeMeasurement` sometimes did not drop gates it should have.
* Bugfix: The demos did not actually use the simplified circuits.
* Some cleanup.

COMP-160