### PR TITLE
Fix linting issues

### DIFF
--- a/tests/test_adonis.py
+++ b/tests/test_adonis.py
@@ -163,7 +163,7 @@ class TestGateDecomposition:
             return True
         for op in op_or_op_list:
             if not Adonis.is_native_operation(op):
-                raise TypeError('Non-native operation: {}'.format(op))
+                raise TypeError(f'Non-native operation: {op}')
         return True
 
     @pytest.mark.parametrize('gate', native_1q_gates)

--- a/tests/test_valkmusa.py
+++ b/tests/test_valkmusa.py
@@ -132,7 +132,7 @@ class TestGateDecomposition:
             return True
         for op in op_or_op_list:
             if not Valkmusa.is_native_operation(op):
-                raise TypeError('Non-native operation: {}'.format(op))
+                raise TypeError(f'Non-native operation: {op}')
         return True
 
     @pytest.mark.parametrize('gate', native_1q_gates)


### PR DESCRIPTION
pylint version `2.11.*` was released overnight, and the linting job is failing with 

```
Formatting a regular string which could be a f-string (consider-using-f-string)
```
Updated the failing lines to comply with the new pylint version.

P.S.
The relevant line from pylint changelog:
```
Added consider-using-f-string: Emitted when .format() or '%' is being used to format a string.

Closes #3592
```
