### PR TITLE
Pass secrets to the workflow call

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,11 @@ on:
     types: [published]
   workflow_dispatch:
   workflow_call:
+    secrets:
+      PYPI_USER:
+        required: true
+      PYPI_PASSWORD:
+        required: true
 
 jobs:
   push_to_pypi:

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -35,8 +35,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # GitHub works so that events ('release' event in this case) triggered by the GITHUB_TOKEN will not create a new
-  # workflow run. This means the publishing workflow will not be triggered even though a new release is successfully
+  # GitHub works so that events ('release' event in this case) triggered while using the GITHUB_TOKEN will not create a
+  # new workflow run. This means the publishing workflow will not be triggered even though a new release is successfully
   # created by the above job create_tag_and_release. Here we trigger the said workflow manually.
   trigger_publishing:
     needs: create_tag_and_release

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -35,6 +35,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # GitHub works so that events ('release' event in this case) triggered by the GITHUB_TOKEN will not create a new
+  # workflow run. This means the publishing workflow will not be triggered even though a new release is successfully
+  # created by the above job create_tag_and_release. Here we trigger the said workflow manually.
   trigger_publishing:
     needs: create_tag_and_release
     uses: iqm-finland/cirq-on-iqm/.github/workflows/publish.yml@main
+    secrets:
+      PYPI_USER: ${{ secrets.PYPI_USER }}
+      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
When the publish workflow is triggered from another workflow it will fail unless necessary secrets as passed to it from the caller workflow. This PR adds these secrets to the workflow call.


COMP-212