### PR TITLE
Checkout last tagged commit in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -50,6 +52,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev, docs]"
           sudo apt-get install graphviz
+      - name: Checkout latest tagged commit
+        run: |
+          git checkout $(git tag -l | tail -1)
+          tox -e build
       - name: Build docs
         run: |
           tox -e docs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,6 @@ jobs:
       - name: Checkout latest tagged commit
         run: |
           git checkout $(git tag -l | tail -1)
-          tox -e build
       - name: Build docs
         run: |
           tox -e docs


### PR DESCRIPTION
In order to get clean release number, the docs must be built on a tagged commit.
Add checkout step to `publish_docs` job to get to the last tagged commit.
Tags are available only if `actions/checkout@v2` fetches the full history.
For that to happen it needs parameter `fetch-depth: 0`.