### PR TITLE
Use git describe to get the latest tag in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
           sudo apt-get install graphviz
       - name: Checkout latest tagged commit
         run: |
-          git checkout $(git tag -l | tail -1)
+          git checkout $(git describe --tags --abbrev=0)
       - name: Build docs
         run: |
           tox -e docs


### PR DESCRIPTION
Selecting latest tag with `git tag -l | tail -1` will not work when release number grows to double-digits because `git tag` lists tags in alphabetical order.  Use `git describe --tags --abbrev=0` instead to get the latest tag in current branch. 