### PR TITLE
Bump Cirq dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ package_dir =
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 install_requires =
     numpy
-    cirq ~= 0.13
+    cirq ~= 0.14
     ply  # required by cirq.contrib.qasm_import
     iqm-client >= 1.5, < 2.0
 

--- a/src/cirq_iqm/iqm_sampler.py
+++ b/src/cirq_iqm/iqm_sampler.py
@@ -161,4 +161,4 @@ class IQMSampler(cirq.work.Sampler):
         job_id = self._client.submit_circuit(iqm_circuit, qubit_mapping, repetitions)
         results = self._client.wait_for_results(job_id)
         measurements = {k: np.array(v) for k, v in results.measurements.items()}
-        return study.Result(params=resolver.ParamResolver(), measurements=measurements)
+        return study.ResultDict(params=resolver.ParamResolver(), measurements=measurements)


### PR DESCRIPTION
The latest minor release (0.14.0) of Cirq, released yesterday, is not backwards compatible with the previous version 0.13.1. Now the `cirq.study.Result` class is abstract and cannot be instantiated. This PR upgrades the Cirq dependency.