### PR TITLE
Update tests, sampler for cirq 0.15 deprecations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 3.6
+===========
+
+* Update optimizers, tests and relevant Jupyter examples to fix deprecation warnings in preparation for cirq 0.15 and cirq 1.0. `#70 <https://github.com/iqm-finland/cirq-on-iqm/pull/70>`_
+
 Version 3.5
 ===========
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -77,7 +77,6 @@ Construct a circuit and use arbitrary qubits:
 .. code-block:: python
 
     import cirq
-    from cirq_iqm import Adonis
 
     q1, q2 = cirq.NamedQubit('Alice'), cirq.NamedQubit('Bob')
     circuit_1 = cirq.Circuit()

--- a/examples/usage.ipynb
+++ b/examples/usage.ipynb
@@ -278,7 +278,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.5"
   },
   "pycharm": {
    "stem_cell": {

--- a/examples/usage.ipynb
+++ b/examples/usage.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 91,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 102,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "a, b, c = adonis.qubits[:3]\n",
-    "circuit = cirq.Circuit(device=adonis)\n",
+    "circuit = cirq.Circuit()\n",
     "circuit.append(cirq.X(a))\n",
     "circuit.append(cirq.PhasedXPowGate(phase_exponent=0.3, exponent=0.5)(c))\n",
     "circuit.append(cirq.CZ(a, c))\n",
@@ -83,17 +83,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Insert non-native gates, which are immediately decomposed into native ones"
+    "Insert non-native gates and decompose them into native ones by calling `decompose_circuit`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 103,
    "metadata": {},
    "outputs": [],
    "source": [
     "circuit.append(cirq.ZZPowGate(exponent=0.2, global_shift=-0.5)(a, c))\n",
     "circuit.append(cirq.HPowGate(exponent=-0.4)(a))\n",
+    "circuit = adonis.decompose_circuit(circuit)\n",
     "print(circuit)"
    ]
   },
@@ -108,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 110,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -119,17 +120,17 @@
     "circuit = cirq.Circuit([\n",
     "    cirq.H(a),\n",
     "    cirq.CNOT(a, c),\n",
-    "    cirq.measure(a, c, key='result'),\n",
-    "], device=adonis)\n",
+    "    cirq.measure(a, c, key='result')])\n",
     "print(circuit)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 111,
    "metadata": {},
    "outputs": [],
    "source": [
+    "circuit = adonis.decompose_circuit(circuit)\n",
     "circuit = simplify_circuit(circuit)\n",
     "print(circuit)"
    ]
@@ -277,7 +278,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.7"
   },
   "pycharm": {
    "stem_cell": {

--- a/examples/usage.ipynb
+++ b/examples/usage.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/src/cirq_iqm/iqm_sampler.py
+++ b/src/cirq_iqm/iqm_sampler.py
@@ -117,14 +117,11 @@ class IQMSampler(cirq.work.Sampler):
         if len(sweeps) > 1 or len(sweeps[0].keys) > 0:
             raise NotImplementedError('Sweeps are not supported')
 
-        if program.device is cirq.UNCONSTRAINED_DEVICE:
-            # verify that qubit_mapping covers all qubits in the circuit
-            circuit_qubits = set(qubit.name for qubit in program.all_qubits())
-            diff = circuit_qubits - set(self._qubit_mapping)
-            if diff:
-                raise ValueError(f'The qubits {diff} are not found in the provided qubit mapping.')
-        elif program.device != self._device:
-            raise ValueError('The devices of the given circuit and of the sampler are not the same.')
+        # verify that qubit_mapping covers all qubits in the circuit
+        circuit_qubits = set(qubit.name for qubit in program.all_qubits())
+        diff = circuit_qubits - set(self._qubit_mapping)
+        if diff:
+            raise ValueError(f'The qubits {diff} are not found in the provided qubit mapping.')
 
         # apply qubit_mapping
         qubit_map = {cirq.NamedQubit(k): cirq.NamedQubit(v) for k, v in self._qubit_mapping.items()}

--- a/src/cirq_iqm/optimizers.py
+++ b/src/cirq_iqm/optimizers.py
@@ -39,8 +39,7 @@ def simplify_circuit(
     This sequence of optimization passes is repeated until the circuit hits a fixed point,
     or ``max_iterations`` is exceeded.
 
-    Finally, it removes Z rotations that are immediately followed by a Z-basis measurement,
-    and runs :meth:`operation_final_decomposer` on the circuit.
+    Finally, it removes Z rotations that are immediately followed by a Z-basis measurement.
 
     Args:
         circuit: circuit to simplify

--- a/src/cirq_iqm/optimizers.py
+++ b/src/cirq_iqm/optimizers.py
@@ -18,7 +18,7 @@ import operator
 from typing import Optional
 
 import cirq
-from cirq import circuits, ops, optimizers
+from cirq import circuits, ops
 
 
 def simplify_circuit(
@@ -61,17 +61,18 @@ def simplify_circuit(
 
         # all mergeable 2-qubit gates are merged
         MergeOneParameterGroupGates().optimize_circuit(c)
-        optimizers.merge_single_qubit_gates_into_phased_x_z(c)
+        c = cirq.merge_single_qubit_gates_to_phased_x_and_z(c)
         # all z rotations are pushed past the first two-qubit gate following them
-        optimizers.EjectZ(eject_parameterized=True).optimize_circuit(c)
-        optimizers.DropEmptyMoments().optimize_circuit(c)
+        c = cirq.eject_z(c, eject_parameterized=True)
+        c = cirq.drop_empty_moments(c)
 
         if c == before:
             # the optimization hit a fixed point
             break
 
     DropRZBeforeMeasurement(drop_final=drop_final_rz).optimize_circuit(c)
-    optimizers.DropEmptyMoments().optimize_circuit(c)
+    # optimizers.DropEmptyMoments().optimize_circuit(c)
+    c = cirq.drop_empty_moments(c)
 
     return c
 

--- a/tests/test_adonis.py
+++ b/tests/test_adonis.py
@@ -235,7 +235,7 @@ class TestCircuitValidation:
         """A valid circuit should pass validation."""
         q0, q1 = adonis.qubits[:2]
 
-        valid_circuit = cirq.Circuit(device=adonis)
+        valid_circuit = cirq.Circuit()
         valid_circuit.append(cirq.Y(q0))
         valid_circuit.append(cirq.measure(q0, key='a'))
         valid_circuit.append(cirq.measure(q1, key='b'))
@@ -247,7 +247,7 @@ class TestCircuitValidation:
 
         q0, q1 = adonis.qubits[:2]
 
-        invalid_circuit = cirq.Circuit(device=adonis)
+        invalid_circuit = cirq.Circuit()
         invalid_circuit.append(cirq.Y(q0))
         invalid_circuit.append(cirq.measure(q0, key='a'))
         invalid_circuit.append(cirq.measure(q1, key='a'))

--- a/tests/test_iqm_sampler.py
+++ b/tests/test_iqm_sampler.py
@@ -21,7 +21,7 @@ from iqm_client.iqm_client import (IQMClient, RunResult, RunStatus,
                                    SingleQubitMapping)
 from mockito import ANY, mock, when
 
-from cirq_iqm import Adonis, Valkmusa
+from cirq_iqm import Adonis
 from cirq_iqm.iqm_sampler import IQMSampler, serialize_qubit_mapping
 
 
@@ -73,13 +73,6 @@ def test_credentials_are_passed_to_client(settings_dict):
     sampler = IQMSampler('http://url', json.dumps(settings_dict), Adonis(), None, username=username, api_key=api_key)
     assert sampler._client._credentials[0] == username
     assert sampler._client._credentials[1] == api_key
-
-
-def test_circuit_with_incorrect_device(adonis_sampler):
-    circuit = cirq.Circuit(device=Valkmusa())
-    with pytest.raises(ValueError, match='devices .* not the same'):
-        adonis_sampler.run(circuit)
-
 
 def test_non_injective_qubit_mapping(base_url, settings_dict, qubit_mapping):
     qubit_mapping['q2 log.'] = 'QB1'

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -18,7 +18,7 @@
 
 import cirq
 import pytest
-from cirq import ops, optimizers
+from cirq import ops
 
 from cirq_iqm.optimizers import (DropRZBeforeMeasurement,
                                  MergeOneParameterGroupGates, simplify_circuit)
@@ -55,7 +55,7 @@ class TestGateOptimization:
         ])
 
         MergeOneParameterGroupGates().optimize_circuit(c)
-        cirq.optimizers.DropEmptyMoments().optimize_circuit(c)
+        c = cirq.drop_empty_moments(c)
 
         if abs((a + b) % MergeOneParameterGroupGates.PERIOD) < 1e-10:
             # the gates have canceled each other out
@@ -99,8 +99,8 @@ class TestGateOptimization:
             cirq.MeasurementGate(1, key='q1')(q1),
         ])
 
-        optimizers.EjectZ().optimize_circuit(c)
-        cirq.optimizers.DropEmptyMoments().optimize_circuit(c)
+        c = cirq.eject_z(c)
+        c = cirq.drop_empty_moments(c)
 
         # the ZPowGates have been commuted and canceled
         assert len(c) == 2


### PR DESCRIPTION
It won't be possible to attach devices to circuits in Cirq 0.15. This updates circuit execution tests and IQM sampler accordingly.