### PR TITLE
Apollo 20-qubit architecture support

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ Contributors
 * Caspar Ockeloen-Korppi <caspar@meetiqm.com>
 * Maxim Smirnov <dc914337@gmail.com>
 * Maija Nevala <maija@meetiqm.com>
+* Rakhim Davletkaliyev <rakhim.davletkaliyev@meetiqm.com>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 Version 3.7
 ===========
 
-* Add support for 20-qubit Apollo architecture. `#71 <https://github.com/iqm-finland/cirq-on-iqm/pull/71>`_
+* Add support for 20-qubit Apollo architecture. `#72 <https://github.com/iqm-finland/cirq-on-iqm/pull/72>`_
 
 Version 3.6
 ===========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 3.7
+===========
+
+* Add support for 20-qubit Apollo architecture. `#71 <https://github.com/iqm-finland/cirq-on-iqm/pull/71>`_
+
 Version 3.6
 ===========
 

--- a/README.rst
+++ b/README.rst
@@ -50,4 +50,4 @@ Copyright
 
 Cirq on IQM is free software, released under the Apache License, version 2.0.
 
-Copyright 2020–2021 Cirq on IQM developers.
+Copyright 2020–2022 Cirq on IQM developers.

--- a/examples/demo_apollo.py
+++ b/examples/demo_apollo.py
@@ -1,4 +1,4 @@
-# Copyright 2020–2021 Cirq on IQM developers
+# Copyright 2020–2022 Cirq on IQM developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/demo_apollo.py
+++ b/examples/demo_apollo.py
@@ -1,0 +1,58 @@
+# Copyright 2020–2021 Cirq on IQM developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Demonstrates importing a quantum circuit from an OpenQASM 2.0 file, transforming it into
+the Apollo native gateset and connectivity, and then executing it on a simulator.
+"""
+import cirq
+from demo_common import demo
+
+from cirq_iqm.devices import Apollo
+from cirq_iqm.extended_qasm_parser import circuit_from_qasm
+
+
+def demo_apollo(do_measure=False, use_qsim=False):
+    """Run the demo using the Apollo architecture."""
+
+    print('\nApollo demo\n===========\n')
+    device = Apollo()
+    qasm_program = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[6];
+        creg meas[3];
+        U(0.2, 0.5, 1.7) q[1];
+        h q[0];
+        h q[2];
+        h q[4];
+        h q[5];
+        cx q[2], q[1];
+        cx q[3], q[5];
+    """
+    if do_measure:
+        qasm_program += '\nmeasure q -> meas;'
+
+    circuit = circuit_from_qasm(qasm_program)
+
+    # add some more gates
+    q0 = cirq.NamedQubit('q_0')
+    q5 = cirq.NamedQubit('q_5')
+    circuit.insert(len(circuit) - 1, cirq.CXPowGate(exponent=0.723)(q5, q0))
+
+    qubit_mapping = {'q_0': 'QB1', 'q_1': 'QB2', 'q_2': 'QB3', 'q_3': 'QB4', 'q_4': 'QB5', 'q_5': 'QB6'}
+    demo(device, circuit, do_measure, use_qsim=use_qsim, qubit_mapping=qubit_mapping)
+
+
+if __name__ == '__main__':
+    demo_apollo()

--- a/examples/demo_apollo.py
+++ b/examples/demo_apollo.py
@@ -37,8 +37,8 @@ def demo_apollo(do_measure=False, use_qsim=False):
         h q[2];
         h q[4];
         h q[5];
-        cx q[2], q[1];
-        cx q[3], q[5];
+        cx q[0], q[1];
+        cx q[3], q[4];
     """
     if do_measure:
         qasm_program += '\nmeasure q -> meas;'
@@ -46,9 +46,9 @@ def demo_apollo(do_measure=False, use_qsim=False):
     circuit = circuit_from_qasm(qasm_program)
 
     # add some more gates
-    q0 = cirq.NamedQubit('q_0')
-    q5 = cirq.NamedQubit('q_5')
-    circuit.insert(len(circuit) - 1, cirq.CXPowGate(exponent=0.723)(q5, q0))
+    q2 = cirq.NamedQubit('q_2')
+    q3 = cirq.NamedQubit('q_3')
+    circuit.insert(len(circuit) - 1, cirq.CXPowGate(exponent=0.723)(q2, q3))
 
     qubit_mapping = {'q_0': 'QB1', 'q_1': 'QB2', 'q_2': 'QB3', 'q_3': 'QB4', 'q_4': 'QB5', 'q_5': 'QB6'}
     demo(device, circuit, do_measure, use_qsim=use_qsim, qubit_mapping=qubit_mapping)

--- a/examples/usage.ipynb
+++ b/examples/usage.ipynb
@@ -310,7 +310,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Insert non-native gates and decompose them into native ones by calling `decompose_circuit`"
+    "Insert non-native gates and decompose the circuit so that it contains native gates only"
    ]
   },
   {

--- a/examples/usage.ipynb
+++ b/examples/usage.ipynb
@@ -8,12 +8,12 @@
    "source": [
     "try:\n",
     "    import cirq\n",
-    "    from cirq_iqm import Adonis, circuit_from_qasm\n",
+    "    from cirq_iqm import Adonis, Apollo, circuit_from_qasm\n",
     "    from cirq_iqm.optimizers import simplify_circuit\n",
     "except ImportError:\n",
     "    print('Installing missing dependencies...')\n",
     "    !pip install --quiet cirq cirq_iqm\n",
-    "    from cirq_iqm import Adonis, circuit_from_qasm\n",
+    "    from cirq_iqm import Adonis, Apollo, circuit_from_qasm\n",
     "    from cirq_iqm.optimizers import simplify_circuit\n",
     "    print('Installation ready')"
    ]
@@ -168,9 +168,7 @@
     }
    },
    "source": [
-    "Note that the above output vector represents the state before the measurement in the optimized circuit, not the original\n",
-    " one, which would have the same phase for both terms. `simplify_circuit` has eliminated a `ZPowGate` which\n",
-    " has no effect on the measurement.\n",
+    "Note that the above output vector represents the state before the measurement in the optimized circuit, not the original one, which would have the same phase for both terms. `simplify_circuit` has eliminated a `ZPowGate` which has no effect on the measurement.\n",
     "\n",
     "---\n",
     "\n",
@@ -260,6 +258,137 @@
    "source": [
     "See the `examples` directory for more examples."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "# The Apollo architecture\n",
+    "\n",
+    "This section describes the same workflow using the 20-qubit Apollo architecture.\n",
+    "\n",
+    "Qubit connectivity:\n",
+    "```\n",
+    "            QB20   QB17\n",
+    "            /  |   /  |\n",
+    "         QB19  QB16  QB12\n",
+    "        /  |   /  |  /  |\n",
+    "     QB18  QB15  QB11  QB7\n",
+    "        |  /  |  /  |  /\n",
+    "        QB14  QB10  QB6\n",
+    "        /  |  /  |  /\n",
+    "     QB13  QB9    QB5\n",
+    "        |  /  |  /  |\n",
+    "        QB8   QB4   QB2\n",
+    "          |  /  |  /\n",
+    "          QB3   QB1\n",
+    "```\n",
+    "Construct an `IQMDevice` instance representing the Adonis architecture"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    },
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "apollo = Apollo()\n",
+    "print(apollo.NATIVE_GATES)\n",
+    "print(apollo.NATIVE_GATE_INSTANCES)\n",
+    "print(apollo.qubits)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a circuit and insert native gates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a, b, c, d, e, f = apollo.qubits[:6]\n",
+    "circuit = cirq.Circuit()\n",
+    "circuit.append(cirq.CZ(a, b))\n",
+    "circuit.append(cirq.CZ(a, c))\n",
+    "circuit.append(cirq.YPowGate(exponent=1.1)(d))\n",
+    "circuit.append(cirq.YPowGate(exponent=1.1)(e))\n",
+    "circuit.append(cirq.PhasedXPowGate(phase_exponent=0.3, exponent=0.5)(f))\n",
+    "print(circuit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Insert non-native gates and decompose them into native ones by calling `decompose_circuit`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "circuit.append(cirq.ZZPowGate(exponent=0.2, global_shift=-0.5)(d, e))\n",
+    "circuit.append(cirq.HPowGate(exponent=-0.4)(f))\n",
+    "circuit = adonis.decompose_circuit(circuit)\n",
+    "print(circuit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the `simplify_circuit` method to run a sequence of optimization passes on a circuit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "circuit = adonis.decompose_circuit(circuit)\n",
+    "circuit = simplify_circuit(circuit)\n",
+    "print(circuit)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "circuit.append(cirq.measure(a, f, key='result'))\n",
+    "\n",
+    "sim = cirq.Simulator()\n",
+    "samples = sim.run(circuit, repetitions=100)\n",
+    "\n",
+    "print('Samples:')\n",
+    "print(samples.histogram(key='result'))\n",
+    "print('\\nState before the measurement:')\n",
+    "result = sim.simulate(circuit[:-1])\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the above output vector represents the state before the measurement in the optimized circuit, not the original one, which would have the same phase for both terms. `simplify_circuit` has eliminated a `ZPowGate` which has no effect on the measurement."
+   ]
   }
  ],
  "metadata": {
@@ -278,7 +407,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.12"
   },
   "pycharm": {
    "stem_cell": {

--- a/examples/usage.ipynb
+++ b/examples/usage.ipynb
@@ -413,7 +413,7 @@
    "stem_cell": {
     "cell_type": "raw",
     "source": [
-     "# Copyright 2020–2021 Cirq on IQM developers\n",
+     "# Copyright 2020–2022 Cirq on IQM developers\n",
      "#\n",
      "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
      "# you may not use this file except in compliance with the License.\n",

--- a/examples/usage.ipynb
+++ b/examples/usage.ipynb
@@ -24,15 +24,7 @@
    "source": [
     "# The Adonis architecture\n",
     "\n",
-    "Qubit connectivity:\n",
-    "```\n",
-    "      QB1\n",
-    "       |\n",
-    "QB4 - QB3 - QB2\n",
-    "       |\n",
-    "      QB5\n",
-    "```\n",
-    "Construct an `IQMDevice` instance representing the Adonis architecture"
+    "Construct an `IQMDevice` instance representing the Adonis architecture, print its qubit connectivity and description"
    ]
   },
   {
@@ -46,6 +38,7 @@
    "outputs": [],
    "source": [
     "adonis = Adonis()\n",
+    "print(adonis.__doc__)\n",
     "print(adonis.NATIVE_GATES)\n",
     "print(adonis.NATIVE_GATE_INSTANCES)\n",
     "print(adonis.qubits)"
@@ -269,23 +262,7 @@
     "\n",
     "This section describes the same workflow using the 20-qubit Apollo architecture.\n",
     "\n",
-    "Qubit connectivity:\n",
-    "```\n",
-    "            QB20   QB17\n",
-    "            /  |   /  |\n",
-    "         QB19  QB16  QB12\n",
-    "        /  |   /  |  /  |\n",
-    "     QB18  QB15  QB11  QB7\n",
-    "        |  /  |  /  |  /\n",
-    "        QB14  QB10  QB6\n",
-    "        /  |  /  |  /\n",
-    "     QB13  QB9    QB5\n",
-    "        |  /  |  /  |\n",
-    "        QB8   QB4   QB2\n",
-    "          |  /  |  /\n",
-    "          QB3   QB1\n",
-    "```\n",
-    "Construct an `IQMDevice` instance representing the Apollo architecture"
+    "Construct an `IQMDevice` instance representing the Apollo architecture, print its qubit connectivity and description"
    ]
   },
   {
@@ -300,6 +277,7 @@
    "outputs": [],
    "source": [
     "apollo = Apollo()\n",
+    "print(apollo.__doc__)\n",
     "print(apollo.NATIVE_GATES)\n",
     "print(apollo.NATIVE_GATE_INSTANCES)\n",
     "print(apollo.qubits)"

--- a/examples/usage.ipynb
+++ b/examples/usage.ipynb
@@ -329,7 +329,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Use the `simplify_circuit` method to run a sequence of optimization passes on a circuit"
+    "Use the `simplify_circuit` function to run a sequence of optimization passes on a circuit"
    ]
   },
   {

--- a/examples/usage.ipynb
+++ b/examples/usage.ipynb
@@ -360,13 +360,6 @@
     "result = sim.simulate(circuit[:-1])\n",
     "print(result)"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that the above output vector represents the state before the measurement in the optimized circuit, not the original one, which would have the same phase for both terms. `simplify_circuit` has eliminated a `ZPowGate` which has no effect on the measurement."
-   ]
   }
  ],
  "metadata": {

--- a/examples/usage.ipynb
+++ b/examples/usage.ipynb
@@ -385,7 +385,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.5"
   },
   "pycharm": {
    "stem_cell": {

--- a/examples/usage.ipynb
+++ b/examples/usage.ipynb
@@ -285,7 +285,7 @@
     "          |  /  |  /\n",
     "          QB3   QB1\n",
     "```\n",
-    "Construct an `IQMDevice` instance representing the Adonis architecture"
+    "Construct an `IQMDevice` instance representing the Apollo architecture"
    ]
   },
   {
@@ -343,7 +343,7 @@
    "source": [
     "circuit.append(cirq.ZZPowGate(exponent=0.2, global_shift=-0.5)(d, e))\n",
     "circuit.append(cirq.HPowGate(exponent=-0.4)(f))\n",
-    "circuit = adonis.decompose_circuit(circuit)\n",
+    "circuit = apollo.decompose_circuit(circuit)\n",
     "print(circuit)"
    ]
   },
@@ -360,7 +360,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "circuit = adonis.decompose_circuit(circuit)\n",
+    "circuit = apollo.decompose_circuit(circuit)\n",
     "circuit = simplify_circuit(circuit)\n",
     "print(circuit)"
    ]

--- a/src/cirq_iqm/devices/__init__.py
+++ b/src/cirq_iqm/devices/__init__.py
@@ -15,5 +15,6 @@
 """
 
 from .adonis import Adonis
+from .apollo import Apollo
 from .iqm_device import IQMDevice
 from .valkmusa import Valkmusa

--- a/src/cirq_iqm/devices/apollo.py
+++ b/src/cirq_iqm/devices/apollo.py
@@ -96,7 +96,7 @@ class Apollo(IQMDevice):
     )
 
     def operation_decomposer(self, op: cirq.Operation) -> Optional[list[cirq.Operation]]:
-        # Decomposes gates into the native Adonis gate set.
+        # Decomposes gates into the native Apollo gate set.
         # All the decompositions below keep track of global phase (required for decomposing controlled gates).
         # It seems that Cirq native decompositions ignore global phase entirely?
 

--- a/src/cirq_iqm/devices/apollo.py
+++ b/src/cirq_iqm/devices/apollo.py
@@ -24,19 +24,19 @@ class Apollo(IQMDevice):
 
     The qubits are connected thus::
 
-          QB20  QB17
-          /  \  /  \
-       QB19  QB16  QB12
-       /  \  /  \  /  \
-    QB18  QB15  QB11  QB7
-       \  /  \  /  \  /
-       QB14  QB10  QB6
-       /  \  /  \  /
-    QB13  QB9   QB5
-       \  /  \  /  \
-       QB8   QB4   QB2
-          \  /  \  /
-          QB3   QB1
+            QB20  QB17
+            /  \  /  \
+         QB19  QB16  QB12
+         /  \  /  \  /  \
+      QB18  QB15  QB11  QB7
+         \  /  \  /  \  /
+         QB14  QB10  QB6
+         /  \  /  \  /
+      QB13  QB9   QB5
+         \  /  \  /  \
+         QB8   QB4   QB2
+            \  /  \  /
+            QB3   QB1
 
     where the lines denote which qubit pairs can be subject to two-qubit gates.
 

--- a/src/cirq_iqm/devices/apollo.py
+++ b/src/cirq_iqm/devices/apollo.py
@@ -1,0 +1,149 @@
+# Copyright 2020–2022 Cirq on IQM developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+IQM's Apollo quantum architecture.
+"""
+from __future__ import annotations
+
+from math import pi as PI
+from typing import Optional
+
+import cirq
+from cirq import ops
+
+from .iqm_device import IQMDevice
+
+PI_2 = PI / 2
+
+# common gates used in gate decompositions
+CZ = ops.CZPowGate()
+Lx = ops.rx(PI_2)
+Lxi = ops.rx(-PI_2)
+Ly = ops.ry(PI_2)
+Lyi = ops.ry(-PI_2)
+
+
+class Apollo(IQMDevice):
+    """IQM's twenty-qubit transmon device.
+
+    The qubits are connected thus::
+
+            QB20   QB17
+            /  |  /  |
+        QB19   QB16  QB12
+        /  |   /  |  /  |
+     QB18  QB15  QB11  QB7
+        |  /  |  /  |  /
+        QB14  QB10  QB6
+        /  |  /  |  /
+     QB13  QB9    QB5
+        |  /  |  /  |
+        QB8   QB4   QB2
+          |  /   |  /
+          QB3    QB1
+
+    where the lines denote which qubit pairs can be subject to two-qubit gates.
+
+    Each qubit can be rotated about any axis in the xy plane by an arbitrary angle.
+    Apollo thus has native PhasedXPowGate, XPowGate, and YPowGate gates. The two-qubit gate CZ is
+    native, as well. The qubits can be measured simultaneously or separately once, at the end of
+    the circuit.
+    """
+
+    QUBIT_COUNT = 20
+
+    CONNECTIVITY = (
+        {1, 2}, {1, 4},
+        {2, 5},
+        {3, 4}, {3, 8},
+        {4, 5}, {4, 9},
+        {5, 6}, {5, 10},
+        {6, 7}, {6, 11},
+        {7, 12},
+        {8, 9}, {8, 13},
+        {9, 10}, {9, 14},
+        {10, 11}, {10, 15},
+        {11, 12}, {11, 16},
+        {12, 17},
+        {13, 14},
+        {14, 15}, {14, 18},
+        {15, 16}, {15, 19},
+        {16, 17}, {16, 20},
+        {18, 19},
+        {19, 20}
+    )
+
+    NATIVE_GATES = (
+        ops.PhasedXPowGate,
+        ops.XPowGate,
+        ops.YPowGate,
+        ops.MeasurementGate
+    )
+
+    NATIVE_GATE_INSTANCES = (
+        ops.CZPowGate(),
+    )
+
+    def operation_decomposer(self, op: cirq.Operation) -> Optional[list[cirq.Operation]]:
+        # Decomposes gates into the native Adonis gate set.
+        # All the decompositions below keep track of global phase (required for decomposing controlled gates).
+        # It seems that Cirq native decompositions ignore global phase entirely?
+
+        if isinstance(op.gate, ops.CZPowGate):
+            # decompose CZPowGate using ZZPowGate
+            t = op.gate.exponent
+            s = op.gate.global_shift
+            L = ops.rz(t / 2 * PI)
+            return [
+                ops.ZZPowGate(exponent=-0.5 * t, global_shift=-2 * s - 1).on(*op.qubits),
+                L.on(op.qubits[0]),
+                L.on(op.qubits[1]),
+            ]
+        if isinstance(op.gate, ops.ZZPowGate):
+            # decompose ZZPowGate using two CZs
+            t = op.gate.exponent
+            s = op.gate.global_shift
+            return [
+                Lyi.on(op.qubits[1]),
+                CZ.on(*op.qubits),
+                ops.XPowGate(exponent=-t, global_shift=-1 - s).on(op.qubits[1]),
+                CZ.on(*op.qubits),
+                Ly.on(op.qubits[1]),
+            ]
+        if isinstance(op.gate, ops.ISwapPowGate):
+            # decompose ISwapPowGate using two CZs
+            t = op.gate.exponent
+            s = op.gate.global_shift
+            x = -0.5 * t
+            return [
+                Lxi.on(op.qubits[0]),
+                Lxi.on(op.qubits[1]),
+                Lyi.on(op.qubits[1]),
+                CZ.on(*op.qubits),
+                ops.XPowGate(exponent=x, global_shift=-0.5 -2 * s).on(op.qubits[0]),
+                ops.XPowGate(exponent=-x, global_shift=-0.5).on(op.qubits[1]),
+                CZ.on(*op.qubits),
+                Ly.on(op.qubits[1]),
+                Lx.on(op.qubits[0]),
+                Lx.on(op.qubits[1]),
+            ]
+        if isinstance(op.gate, ops.ZPowGate):
+            # Rz using Rx, Ry
+            q = op.qubits[0]
+            return [
+                ops.XPowGate(exponent=-0.5).on(q),
+                ops.YPowGate(exponent=op.gate.exponent).on(q),
+                ops.XPowGate(exponent=0.5).on(q),
+            ]
+        return None

--- a/src/cirq_iqm/devices/apollo.py
+++ b/src/cirq_iqm/devices/apollo.py
@@ -40,8 +40,8 @@ class Apollo(IQMDevice):
     The qubits are connected thus::
 
             QB20   QB17
-            /  |  /  |
-        QB19   QB16  QB12
+            /  |   /  |
+         QB19  QB16  QB12
         /  |   /  |  /  |
      QB18  QB15  QB11  QB7
         |  /  |  /  |  /
@@ -50,8 +50,8 @@ class Apollo(IQMDevice):
      QB13  QB9    QB5
         |  /  |  /  |
         QB8   QB4   QB2
-          |  /   |  /
-          QB3    QB1
+          |  /  |  /
+          QB3   QB1
 
     where the lines denote which qubit pairs can be subject to two-qubit gates.
 

--- a/src/cirq_iqm/devices/valkmusa.py
+++ b/src/cirq_iqm/devices/valkmusa.py
@@ -1,4 +1,4 @@
-# Copyright 2020–2021 Cirq on IQM developers
+# Copyright 2020–2022 Cirq on IQM developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ Lzi = ops.rz(-PI_2)
 class Valkmusa(IQMDevice):
     """IQM's two-qubit transmon device.
 
-    ::
+    The qubits are connected thus::
 
       QB1 - QB2
 
@@ -57,6 +57,8 @@ class Valkmusa(IQMDevice):
         ops.ISwapPowGate,
         ops.MeasurementGate
     )
+
+    NATIVE_GATE_INSTANCES = ()
 
     def operation_decomposer(self, op: ops.Operation) -> Optional[list[ops.Operation]]:
         # Decomposes CNOT and the CZPowGate family to Valkmusa native gates.

--- a/tests/test_apollo.py
+++ b/tests/test_apollo.py
@@ -1,0 +1,466 @@
+# Copyright 2020–2021 Cirq on IQM developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Apollo device.
+"""
+# pylint: disable=redefined-outer-name,no-self-use,duplicate-code
+
+from __future__ import annotations
+
+import cirq
+import numpy as np
+import pytest
+from cirq import IdentityGate
+
+from cirq_iqm import Apollo
+
+
+def dist(U: np.ndarray, W: np.ndarray) -> float:
+    r"""Distance between two unitary matrices, modulo global phase.
+
+    Returns:
+        minimal squared Frobenius norm distance between the unitaries over all global phases
+
+    .. math::
+       \mathrm{dist}(U, W) = \inf_{\phi \in \mathbb{R}} \|U - e^{i \phi} W\|_F^2
+       = 2 (\dim_A - |\mathrm{Tr}(U^\dagger W)|)
+    """
+    return 2 * (len(U) - np.abs(np.trace(U.T.conj() @ W)))
+
+
+@pytest.fixture(scope='module')
+def apollo():
+    """Apollo device fixture."""
+    return Apollo()
+
+
+# define various groups of gates to test
+
+native_1q_gates = [
+    cirq.X,
+    cirq.Y,
+    cirq.XPowGate(exponent=0.23),
+    cirq.YPowGate(exponent=0.71),
+    cirq.PhasedXPowGate(phase_exponent=1.7, exponent=-0.58),
+]
+
+native_2q_gates = [
+    cirq.CZ,
+]
+
+non_native_1q_gates = [
+    cirq.H,
+    cirq.Z,
+    cirq.ZPowGate(exponent=-0.23),
+    cirq.HPowGate(exponent=-0.55),
+    cirq.PhasedXZGate(x_exponent=0.2, z_exponent=-0.5, axis_phase_exponent=0.75),
+]
+
+non_native_2q_gates = [
+    cirq.ISWAP,
+    cirq.ISwapPowGate(exponent=0.27),
+    cirq.SWAP,
+    cirq.CNOT,
+    cirq.CXPowGate(exponent=-2.2),
+    cirq.CZPowGate(exponent=1.6),
+    cirq.ZZPowGate(exponent=-0.94),
+]
+
+
+class TestOperationValidation:
+    """Nativity and validation of various operations."""
+
+    @pytest.mark.parametrize('gate', native_1q_gates)
+    @pytest.mark.parametrize('q', [0, 2, 3])
+    def test_native_single_qubit_gates(self, apollo, gate, q):
+        """Native operations must pass validation."""
+
+        apollo.validate_operation(gate(apollo.qubits[q]))
+        apollo.validate_operation(gate(apollo.qubits[q]).with_tags('tag_foo'))
+
+    @pytest.mark.parametrize('gate', native_2q_gates)
+    def test_native_two_qubit_gates(self, apollo, gate):
+        """Native operations must pass validation."""
+
+        q0, q1 = apollo.qubits[:2]
+
+        apollo.validate_operation(gate(q0, q1))
+        apollo.validate_operation(gate(q1, q0))
+
+    @pytest.mark.parametrize('meas', [
+        cirq.measure,
+        lambda q: cirq.measure(q, key='test'),
+    ])
+    def test_native_measurements(self, apollo, meas):
+        """Native operations must pass validation."""
+
+        apollo.validate_operation(meas(apollo.qubits[0]))
+
+    @pytest.mark.parametrize('gate', non_native_1q_gates)
+    def test_non_native_single_qubit_gates(self, apollo, gate):
+        """Non-native operations must not pass validation."""
+
+        q0 = apollo.qubits[0]
+
+        with pytest.raises(ValueError, match='Unsupported gate type'):
+            apollo.validate_operation(gate(q0))
+
+        with pytest.raises(ValueError, match='Unsupported gate type'):
+            apollo.validate_operation(gate(q0).with_tags('tag_foo'))
+
+    @pytest.mark.parametrize('gate', non_native_2q_gates)
+    def test_non_native_two_qubit_gates(self, apollo, gate):
+        """Non-native operations must not pass validation."""
+
+        q0, _, q2 = apollo.qubits[:3]
+
+        with pytest.raises(ValueError, match='Unsupported gate type'):
+            apollo.validate_operation(gate(q0, q2))
+
+        with pytest.raises(ValueError, match='Unsupported gate type'):
+            apollo.validate_operation(gate(q2, q0))
+
+    @pytest.mark.parametrize('qubit', [
+        cirq.NamedQubit('xxx'),
+        cirq.GridQubit(0, 1),
+    ])
+    def test_qubits_not_on_device(self, apollo, qubit):
+        """Gates operating on qubits not on device must not pass validation."""
+
+        with pytest.raises(ValueError, match='Qubit not on device'):
+            apollo.validate_operation(cirq.X(qubit))
+
+    @pytest.mark.parametrize('gate', native_2q_gates)
+    def test_qubits_not_connected(self, apollo, gate):
+        """Native two-qubit gates operating on non-connected qubits must not pass validation."""
+
+        q0, _, q2 = apollo.qubits[:3]
+
+        with pytest.raises(ValueError, match='Unsupported qubit connectivity'):
+            apollo.validate_operation(gate(q0, q2))
+
+        with pytest.raises(ValueError, match='Unsupported qubit connectivity'):
+            apollo.validate_operation(gate(q2, q0))
+
+
+class TestGateDecomposition:
+    """Decomposing gates."""
+
+    @staticmethod
+    def is_native(op_or_op_list) -> bool:
+        """True iff the op_list consists of native operations only."""
+        if Apollo.is_native_operation(op_or_op_list):
+            return True
+        for op in op_or_op_list:
+            if not Apollo.is_native_operation(op):
+                raise TypeError(f'Non-native operation: {op}')
+        return True
+
+    @pytest.mark.parametrize('gate', native_1q_gates)
+    def test_native_single_qubit_gates(self, apollo, gate):
+        """Native single-qubit gates do not decompose further."""
+
+        q0 = apollo.qubits[0]
+
+        for op in (
+                gate.on(q0),
+                gate.on(q0).with_tags('tag_baz'),
+        ):
+            decomposition = apollo.decompose_operation(op)
+            assert decomposition == op
+            assert TestGateDecomposition.is_native(decomposition)
+
+    @pytest.mark.parametrize('gate', non_native_1q_gates)
+    def test_non_native_single_qubit_gates(self, apollo, gate):
+        """Non-native single qubit gates should decompose into native gates."""
+
+        q1 = apollo.qubits[1]
+
+        for op in (
+                gate.on(q1),
+                gate.on(q1).with_tags('tag_baz'),
+        ):
+            decomposition = apollo.decompose_operation(op)
+            assert TestGateDecomposition.is_native(decomposition)
+
+    @pytest.mark.parametrize('gate', native_2q_gates)
+    def test_native_two_qubit_gate(self, apollo, gate):
+        """Native two-qubit gates do not decompose further."""
+
+        q0, _, q2 = apollo.qubits[:3]
+
+        for op in (
+                gate.on(q0, q2),
+                gate.on(q2, q0).with_tags('tag_baz'),
+        ):
+            decomposition = apollo.decompose_operation(op)
+            assert decomposition == op
+            assert TestGateDecomposition.is_native(decomposition)
+
+    @pytest.mark.parametrize('gate', non_native_2q_gates)
+    def test_non_native_two_qubit_gates(self, apollo, gate):
+        """Non-native two-qubit gates should decompose into native gates."""
+
+        q0, q1, q2 = apollo.qubits[:3]
+
+        for op in (
+                gate.on(q0, q2),
+                gate.on(q2, q0).with_tags('tag_baz'),
+                gate.on(q2, q1),
+        ):
+            decomposition = apollo.decompose_operation(op)
+            assert TestGateDecomposition.is_native(decomposition)
+
+            # matrix representations must match up to global phase
+            U = cirq.Circuit(op)._unitary_()
+            W = cirq.Circuit(decomposition)._unitary_()
+            assert dist(U, W) == pytest.approx(0)
+
+
+class TestCircuitValidation:
+    """Validating entire circuits."""
+
+    def test_valid_circuit(self, apollo):
+        """A valid circuit should pass validation."""
+        q0, q1 = apollo.qubits[:2]
+
+        valid_circuit = cirq.Circuit()
+        valid_circuit.append(cirq.Y(q0))
+        valid_circuit.append(cirq.measure(q0, key='a'))
+        valid_circuit.append(cirq.measure(q1, key='b'))
+
+        apollo.validate_circuit(valid_circuit)
+
+    def test_invalid_circuit(self, apollo):
+        """An invalid circuit should not pass validation."""
+
+        q0, q1 = apollo.qubits[:2]
+
+        invalid_circuit = cirq.Circuit()
+        invalid_circuit.append(cirq.Y(q0))
+        invalid_circuit.append(cirq.measure(q0, key='a'))
+        invalid_circuit.append(cirq.measure(q1, key='a'))
+
+        with pytest.raises(ValueError, match='Measurement key a repeated'):
+            apollo.validate_circuit(invalid_circuit)
+
+
+class TestCircuitDecomposition:
+    def test_decompose_circuit_native_only(self, apollo):
+        """Circuit containing only native ops decomposes trivially.
+        """
+        q0, q1 = cirq.NamedQubit.range(0, 2, prefix='qubit_')
+        circuit = cirq.Circuit(
+            cirq.CZ(q0, q1),
+        )
+        new = apollo.decompose_circuit(circuit)
+
+        # same circuit
+        assert new == circuit
+
+    def test_decompose_circuit(self, apollo):
+        """Any gates should be decomposable to native gates.
+        """
+        q0, q1 = cirq.NamedQubit.range(0, 2, prefix='qubit_')
+        circuit = cirq.Circuit(
+            cirq.CNOT(q0, q1),
+        )
+        new = apollo.decompose_circuit(circuit)
+
+        # still uses the original qubits, not device qubits
+        assert circuit.all_qubits() == new.all_qubits()
+        assert len(new) == 3
+        assert new[1].operations[0].gate == cirq.CZ  # CNOT decomposes into CZ plus Ry:s
+
+    def test_decompose_complicated_circuit(self, apollo):
+        """Can handle even 3-qubit gates.
+        """
+        q0, q1, q2 = cirq.NamedQubit.range(0, 3, prefix='qubit_')
+        circuit = cirq.Circuit(
+            cirq.H(q0),
+            cirq.X(q1),
+            cirq.TOFFOLI(q0, q2, q1),
+            cirq.measure(q0, q1, q2, key='mk')
+        )
+        new = apollo.decompose_circuit(circuit)
+
+        # still uses the original qubits, not device qubits
+        assert circuit.all_qubits() == new.all_qubits()
+        assert len(new) == 31
+
+
+class TestCircuitRouting:
+    @pytest.fixture(scope='class')
+    def qubits(self):
+        return [
+            cirq.NamedQubit('Alice'),
+            cirq.NamedQubit('Bob'),
+            cirq.NamedQubit('Charlie'),
+            cirq.NamedQubit('Dan'),
+            cirq.NamedQubit('Eve'),
+            cirq.NamedQubit('Faythe'),
+            cirq.NamedQubit('Grace'),
+            cirq.NamedQubit('Heidi'),
+            cirq.NamedQubit('Ivan'),
+            cirq.NamedQubit('Judy'),
+            cirq.NamedQubit('Kiuas'),
+            cirq.NamedQubit('Leon'),
+            cirq.NamedQubit('Mallory'),
+            cirq.NamedQubit('Niaj'),
+            cirq.NamedQubit('Olivia'),
+            cirq.NamedQubit('Peggy'),
+            cirq.NamedQubit('Quant'),
+            cirq.NamedQubit('Rupert'),
+            cirq.NamedQubit('Sybil'),
+            cirq.NamedQubit('Trent')
+        ]
+
+    def test_routing_circuit_too_large(self, apollo):
+        """The circuit must fit on the device.
+        """
+        qubits = cirq.NamedQubit.range(0, 21, prefix='qubit_')
+        circuit = cirq.Circuit([cirq.X(q) for q in qubits])
+        with pytest.raises(ValueError, match='Number of logical qubits is greater than number of physical qubits'):
+            apollo.route_circuit(circuit)
+
+    def test_routing_without_SWAPs(self, apollo, qubits):
+        """Circuit graph can be embedded in the Apollo connectivity graph, no SWAPs needed.
+        """
+        circuit = cirq.Circuit(
+            cirq.CZ(*qubits[0:2]),
+            cirq.CZ(*qubits[2:4])
+        )
+        new = apollo.route_circuit(circuit)
+
+        assert len(new.all_qubits()) == 4
+        assert new.all_qubits() <= set(apollo.qubits)
+        assert len(new) == len(circuit) # a SWAP gate was not added
+
+    def test_routing_needs_SWAPs(self, apollo, qubits):
+        """Circuit has cyclic connectivity with 3 qubits, Apollo doesn't, so SWAPs are needed.
+        """
+        circuit = cirq.Circuit(
+            cirq.CZ(qubits[0], qubits[1]),
+            cirq.CZ(qubits[0], qubits[2]),
+            cirq.CZ(qubits[1], qubits[2])
+        )
+        new = apollo.route_circuit(circuit)
+
+        assert len(new.all_qubits()) >= 3    # routing algo may use more qubits
+        assert new.all_qubits() <= set(apollo.qubits)
+        assert len(new) == 4  # a SWAP gate was added
+
+        # SWAPs added by routing can be decomposed
+        with pytest.raises(ValueError, match='Unsupported gate type: cirq.contrib.acquaintance.SwapPermutationGate()'):
+            apollo.validate_circuit(new)
+        decomposed = apollo.decompose_circuit(new)
+        apollo.validate_circuit(decomposed)
+
+    @pytest.mark.parametrize('qid', [
+        cirq.LineQubit(4),
+        cirq.GridQubit(5, 6),
+        cirq.NamedQid('Quentin', dimension=2),
+        cirq.LineQid(4, dimension=2),
+        cirq.GridQid(5, 6, dimension=2),
+    ])
+    def test_routing_with_qids(self, apollo, qid):
+        """Routing can handle all kinds of Qid types, not just NamedQubit.
+        """
+        q = cirq.NamedQubit('Alice')
+        circuit = cirq.Circuit(
+            cirq.X(q),
+            cirq.Y(qid),
+            cirq.CZ(q, qid),
+        )
+        new = apollo.route_circuit(circuit)
+
+        assert len(new.all_qubits()) == 2
+        assert new.all_qubits() <= set(apollo.qubits)
+
+    def test_routed_measurements(self, apollo, qubits):
+        circuit = cirq.Circuit(
+            cirq.CZ(qubits[0], qubits[2]),
+            cirq.CZ(*qubits[0:2]),
+            cirq.CZ(*qubits[1:3]),
+            cirq.measure(qubits[0], key='mk0'),
+            cirq.measure(qubits[1], key='mk1'),
+            cirq.measure(qubits[2], key='mk2'),
+        )
+
+        swap_network = apollo.route_circuit(circuit, return_swap_network=True)
+        circuit_routed = swap_network.circuit
+        mapping = {k.name: v.name for k, v in swap_network.final_mapping().items()}  # physical name to logical name
+
+        assert circuit_routed.are_all_measurements_terminal()
+        assert circuit_routed.all_measurement_key_names() == {'mk0', 'mk1', 'mk2'}
+
+        # Check that measurements in the routed circuit are mapped to correct qubits
+        measurements = [op for _, op, _ in circuit_routed.findall_operations_with_gate_type(cirq.MeasurementGate)]
+        mk_to_physical_name = {op.gate.key: op.qubits[0].name for op in measurements}
+        assert all(len(op.qubits) == 1 for op in measurements)
+        assert mapping[mk_to_physical_name['mk0']] == 'Alice'
+        assert mapping[mk_to_physical_name['mk1']] == 'Bob'
+        assert mapping[mk_to_physical_name['mk2']] == 'Charlie'
+
+    def test_routing_with_multi_qubit_measurements(self, apollo, qubits):
+        circuit = cirq.Circuit(
+            cirq.CZ(*qubits[0:2]),
+            cirq.CZ(*qubits[1:3]),
+            cirq.CZ(*qubits[2:4]),
+            cirq.CZ(*qubits[3:5]),
+            cirq.CZ(*qubits[4:6]),
+            cirq.CZ(*qubits[5:7]),
+            cirq.CZ(*qubits[6:8]),
+            cirq.CZ(*qubits[7:9]),
+            cirq.CZ(*qubits[8:10]),
+            cirq.CZ(*qubits[9:11]),
+            cirq.CZ(*qubits[10:12]),
+            cirq.CZ(*qubits[11:13]),
+            cirq.CZ(*qubits[12:14]),
+            cirq.CZ(*qubits[13:15]),
+            cirq.CZ(*qubits[14:16]),
+            cirq.CZ(*qubits[15:17]),
+            cirq.CZ(*qubits[16:18]),
+            cirq.CZ(*qubits[17:19]),
+            cirq.CZ(*qubits[18:20]),
+            cirq.X(qubits[4]),
+            cirq.CZ(qubits[0], qubits[2]),
+            cirq.CZ(qubits[1], qubits[3]),
+            cirq.CZ(qubits[2], qubits[4]),
+            cirq.CZ(qubits[3], qubits[5]),
+            cirq.CZ(qubits[4], qubits[6]),
+            cirq.CZ(qubits[5], qubits[7]),
+            cirq.CZ(qubits[6], qubits[8]),
+            cirq.CZ(qubits[7], qubits[9]),
+            cirq.CZ(qubits[8], qubits[10]),
+            cirq.CZ(qubits[9], qubits[11]),
+            cirq.CZ(qubits[10], qubits[12]),
+            cirq.measure(*qubits[0:2], key='m1'),
+            cirq.measure(*qubits[2:20], key='m2')
+            )
+        new = apollo.route_circuit(circuit)
+        assert new.all_qubits() == set(apollo.qubits)
+        # Test that all measurements exist.
+        assert new.all_measurement_key_names() == {'m1', 'm2'}
+        # Test that temporary identity gates have been removed
+        assert not list(new.findall_operations_with_gate_type(IdentityGate))
+
+    def test_routing_with_nonterminal_measurements_raises_error(self, apollo):
+        q = cirq.NamedQubit('q1')
+        circuit = cirq.Circuit(
+            cirq.measure(q, key='m'),
+            cirq.Y(q)
+        )
+        with pytest.raises(ValueError, match='Non-terminal measurements are not supported'):
+            apollo.route_circuit(circuit)

--- a/tests/test_iqm_device.py
+++ b/tests/test_iqm_device.py
@@ -1,4 +1,4 @@
-# Copyright 2020–2021 Cirq on IQM developers
+# Copyright 2020–2022 Cirq on IQM developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,13 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from cirq_iqm import Adonis, Valkmusa
+from cirq_iqm import Adonis, Apollo, Valkmusa
 
 
 def test_equality_method():
     adonis_1 = Adonis()
     adonis_2 = Adonis()
+    apollo_1 = Apollo()
+    apollo_2 = Apollo()
     valkmusa = Valkmusa()
 
     assert adonis_1 == adonis_2
     assert valkmusa != adonis_1
+    assert apollo_1 == apollo_2


### PR DESCRIPTION
Support for 20-qubit IQM Apollo architecture.

The Apollo device differs from Adonis only in two aspects: number of qubits and the connectivity of qubits. The native gates are the same in both Apollo and Adonis, so decomposition logic is also the same.