### PR TITLE
Add optional calibration_set_id to IQMSampler

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Version 7.2
 
 * Update ``IQMClient`` instantiations with the changes in iqm-client 6.1. `#80 <https://github.com/iqm-finland/cirq-on-iqm/pull/80>`_
 * ``IQMSampler`` now accepts an optional ``calibration_set_id``. `#80 <https://github.com/iqm-finland/cirq-on-iqm/pull/80>`_
+* Update documentation regarding the use of Cortex CLI. `#80 <https://github.com/iqm-finland/cirq-on-iqm/pull/80>`_
 
 Version 7.1
 ===========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 7.1
+===========
+
+* Update ``IQMClient`` instantiations with the changes in iqm-client 6.1. `#80 <https://github.com/iqm-finland/cirq-on-iqm/pull/80>`_
+* ``IQMSampler`` now accepts an optional ``calibration_set_id``. `#80 <https://github.com/iqm-finland/cirq-on-iqm/pull/80>`_
+
 Version 7.0
 ===========
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -228,14 +228,13 @@ Note that the code snippet above assumes that you have set the variables ``iqm_s
 ``iqm_settings_path``.
 If you want to use the latest calibration set, omit ``settings`` argument from the ``backend.run`` call.
 If you want to use a particular calibration set, provide a ``calibration_set_id`` integer argument. You cannot set both
-``settings`` and ``calibration_set_id`` simultaneously, as IQM server rejects such requests.
+``settings`` and ``calibration_set_id`` simultaneously, because IQM server rejects such requests.
 
 If the IQM server you are connecting to requires authentication, you will also have to set the IQM_AUTH_SERVER,
 IQM_AUTH_USERNAME and IQM_AUTH_PASSWORD environment variables or pass them as arguments to the constructor of
-:class:`.IQMProvider`. Alternatively, you can use `Cortex CLI <https://github.com/iqm-finland/cortex-cli>`_, which
-retrieves access tokens and refreshes them periodically in the background; set the ``IQM_TOKENS_FILE`` environment
-variable to use those tokens. See Cortex CLI's `documentation <https://iqm-finland.github.io/cortex-cli/readme.html>`_
-for details.
+:class:`.IQMProvider`. Alternatively, authorize with `Cortex CLI <https://github.com/iqm-finland/cortex-cli>`_ to
+retrieve and automatically refresh access tokens, then set the ``IQM_TOKENS_FILE`` environment variable to use those
+tokens. See Cortex CLI's `documentation <https://iqm-finland.github.io/cortex-cli/readme.html>`_ for details.
 
 When executing a circuit that uses something other than the device qubits, you need to either route it first
 as explained in :ref:`workflow 1 <workflow_1>` above,

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -225,8 +225,17 @@ and retrieve the results:
 
 
 Note that the code snippet above assumes that you have set the variables ``iqm_server_url`` and
-``iqm_settings_path``. If the IQM server you are connecting to requires authentication, you will also have to set
-the IQM_AUTH_SERVER, IQM_AUTH_USERNAME and IQM_AUTH_PASSWORD environment variables.
+``iqm_settings_path``.
+If you want to use the latest calibration set, omit ``settings`` argument from the ``backend.run`` call.
+If you want to use a particular calibration set, provide a ``calibration_set_id`` integer argument. You cannot set both
+``settings`` and ``calibration_set_id`` simultaneously, as IQM server rejects such requests.
+
+If the IQM server you are connecting to requires authentication, you will also have to set the IQM_AUTH_SERVER,
+IQM_AUTH_USERNAME and IQM_AUTH_PASSWORD environment variables or pass them as arguments to the constructor of
+:class:`.IQMProvider`. Alternatively, you can use `Cortex CLI <https://github.com/iqm-finland/cortex-cli>`_, which
+retrieves access tokens and refreshes them periodically in the background; set the ``IQM_TOKENS_FILE`` environment
+variable to use those tokens. See Cortex CLI's `documentation <https://iqm-finland.github.io/cortex-cli/readme.html>`_
+for details.
 
 When executing a circuit that uses something other than the device qubits, you need to either route it first
 as explained in :ref:`workflow 1 <workflow_1>` above,

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     numpy
     cirq ~= 0.14
     ply  # required by cirq.contrib.qasm_import
-    iqm-client >= 5.0, < 6.0
+    iqm-client >= 6.1, < 7.0
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = ~= 3.9

--- a/tests/test_iqm_sampler.py
+++ b/tests/test_iqm_sampler.py
@@ -151,7 +151,7 @@ def test_credentials_are_passed_to_client():
     assert sampler._client._credentials.password == user_auth_args['password']
 
 
-def test_client_close():
+def test_close_client():
     user_auth_args = {
         'auth_server_url': 'https://fake.auth.server.com',
         'username': 'fake-username',

--- a/tests/test_iqm_sampler.py
+++ b/tests/test_iqm_sampler.py
@@ -70,7 +70,11 @@ def test_run_sweep_executes_circuit(adonis_sampler, circuit, iqm_metadata):
     client = mock(IQMClient)
     run_id = uuid.uuid4()
     run_result = RunResult(status=Status.READY, measurements=[{'some stuff': [[0], [1]]}], metadata=iqm_metadata)
-    when(client).submit_circuits(ANY, qubit_mapping=ANY, settings=ANY, shots=ANY).thenReturn(run_id)
+    when(client).submit_circuits(ANY,
+                                 qubit_mapping=ANY,
+                                 settings=ANY,
+                                 calibration_set_id=ANY,
+                                 shots=ANY).thenReturn(run_id)
     when(client).wait_for_results(run_id).thenReturn(run_result)
 
     adonis_sampler._client = client
@@ -96,7 +100,11 @@ def test_run_sweep_executes_circuit_without_settings(adonis_sampler_without_sett
     client = mock(IQMClient)
     run_id = uuid.uuid4()
     run_result = RunResult(status=Status.READY, measurements=[{'some stuff': [[0], [1]]}], metadata=iqm_metadata)
-    when(client).submit_circuits(ANY, qubit_mapping=ANY, settings=None, shots=ANY).thenReturn(run_id)
+    when(client).submit_circuits(ANY,
+                                 qubit_mapping=ANY,
+                                 settings=None,
+                                 calibration_set_id=ANY,
+                                 shots=ANY).thenReturn(run_id)
     when(client).wait_for_results(run_id).thenReturn(run_result)
 
     adonis_sampler_without_settings._client = client
@@ -110,7 +118,11 @@ def test_run_sweep_with_parameter_sweep(adonis_sampler_without_settings, iqm_met
     run_id = uuid.uuid4()
     run_result = RunResult(
         status=Status.READY, measurements=[{'some stuff': [[0]]}, {'some stuff': [[1]]}], metadata=iqm_metadata)
-    when(client).submit_circuits(ANY, qubit_mapping=ANY, settings=ANY, shots=ANY).thenReturn(run_id)
+    when(client).submit_circuits(ANY,
+                                 qubit_mapping=ANY,
+                                 settings=ANY,
+                                 calibration_set_id=ANY,
+                                 shots=ANY).thenReturn(run_id)
     when(client).wait_for_results(run_id).thenReturn(run_result)
     qubit_1 = cirq.NamedQubit('QB1')
     qubit_2 = cirq.NamedQubit('QB2')


### PR DESCRIPTION
[IQM Client 6.1](https://github.com/iqm-finland/iqm-client/commit/45654f63d3f363f2996d143f145a38cd19785b35) now allows to specify a `calibration_set_id`. This PR updates Cirq-on-IQM accordingly.