### PR TITLE
Implement metadata for IQM devices

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 8.0
+===========
+
+* Implement metadata for IQM devices. `#92 <https://github.com/iqm-finland/cirq-on-iqm/pull/92>`_
+
 Version 7.8
 ===========
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -226,7 +226,7 @@ Note that the code snippet above assumes that you have set the variable ``iqm_se
 of the IQM server. By default, the latest calibration set is used for running the circuit. If you want to use
 a particular calibration set, provide the ``calibration_set_id`` argument. The sampler will by default use an
 :class:`.IQMDevice` created based on architecture data obtained from the server, which is then available in the
-:meth:`.IQMSampler.device` property. Alternatively, the device can be specified directly with the ``device`` argument.
+:attr:`.IQMSampler.device` property. Alternatively, the device can be specified directly with the ``device`` argument.
 
 If the IQM server you are connecting to requires authentication, you will also have to use
 `Cortex CLI <https://github.com/iqm-finland/cortex-cli>`_ to retrieve and automatically refresh access tokens,

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -27,29 +27,32 @@ After installation Cirq on IQM can be imported in your Python code as follows:
 IQM's quantum devices
 ---------------------
 
-Cirq on IQM provides descriptions of IQM's quantum architectures as subclasses of :class:`.IQMDevice`.
-The abstract class :class:`.IQMDevice` itself is a subclass of :class:`cirq.devices.Device` and implements general
-functionality relevant to all IQM devices. Each device subclass describes the native gates and the connectivity of a particular architecture
-and the relevant functionality. As an example, let us import the class :class:`.Adonis`, which describes IQM's
-five-qubit architecture and view some of its properties contained in the class variables:
+Cirq on IQM provides descriptions of IQM's quantum architectures using the :class:`.IQMDevice` class, which is a
+subclass of :class:`cirq.devices.Device` and implements general functionality relevant to all IQM devices. The native
+gates and connectivity of the architecture are available in the :class:`.IQMDeviceMetadata` object returned by the
+:meth:`.IQMDevice.metadata` property of the device. It is possible to use :class:`.IQMDevice` class directly, but
+certain devices with predefined metadata are also available as subclasses of :class:`.IQMDevice`. As an example, let
+us import the class :class:`.Adonis`, which describes IQM's five-qubit architecture and view some of its properties
+contained in the :meth:`.Adonis.metadata` property:
 
 .. code-block:: python
 
     from cirq_iqm import Adonis
 
-    print(Adonis.QUBIT_COUNT)
-    print(Adonis.NATIVE_GATES)
-    print(Adonis.CONNECTIVITY)
+    adonis = Adonis()
+
+    print(adonis.metadata.qubit_set)
+    print(adonis.metadata.gateset)
+    print(adonis.metadata.nx_graph)
 
 
 IQM devices use :class:`cirq.NamedQubit` to represent their qubits. The names of the qubits consist of a prefix
 followed by a numeric index, so we have qubit names like ``QB1``, ``QB2``, etc. Note that we use 1-based
-indexing. The qubit connectivity information is stored using the qubit indices only. You can get the list of the qubits
-in a particular device by accessing the ``qubits`` attribute of a corresponding :class:`.IQMDevice` instance:
+indexing. You can get the list of the qubits in a particular device by accessing the ``qubits`` attribute of a
+corresponding :class:`.IQMDevice` instance:
 
 .. code-block:: python
 
-    adonis = Adonis()
     print(adonis.qubits)
 
 
@@ -214,14 +217,16 @@ instance and use its :meth:`~.IQMSampler.run` method to send a circuit for execu
 
    from cirq_iqm.iqm_sampler import IQMSampler
 
-   sampler = IQMSampler(iqm_server_url, adonis)
+   sampler = IQMSampler(iqm_server_url)
    result = sampler.run(circuit_1, repetitions=10)
    print(result.measurements['m'])
 
 
 Note that the code snippet above assumes that you have set the variable ``iqm_server_url`` to the URL
 of the IQM server. By default, the latest calibration set is used for running the circuit. If you want to use
-a particular calibration set, provide a ``calibration_set_id`` integer argument.
+a particular calibration set, provide a ``calibration_set_id`` integer argument. The sampler will by default use an
+:class:`.IQMDevice` created based on architecture data obtained from the server, which is then available in the
+:meth:`.IQMSampler.device` property. Alternatively, the device can be specified directly with the ``device`` argument.
 
 If the IQM server you are connecting to requires authentication, you will also have to use
 `Cortex CLI <https://github.com/iqm-finland/cortex-cli>`_ to retrieve and automatically refresh access tokens,
@@ -244,7 +249,7 @@ can be used to specify this correspondence.
 
     qubit_mapping = {'Alice': 'QB1', 'Bob': 'QB3'}
 
-    sampler = IQMSampler(iqm_server_url, adonis, qubit_mapping=qubit_mapping)
+    sampler = IQMSampler(iqm_server_url, qubit_mapping=qubit_mapping)
     result = sampler.run(decomposed_circuit_1, repetitions=10)
     print(result.measurements['m'])
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -30,10 +30,10 @@ IQM's quantum devices
 Cirq on IQM provides descriptions of IQM's quantum architectures using the :class:`.IQMDevice` class, which is a
 subclass of :class:`cirq.devices.Device` and implements general functionality relevant to all IQM devices. The native
 gates and connectivity of the architecture are available in the :class:`.IQMDeviceMetadata` object returned by the
-:meth:`.IQMDevice.metadata` property of the device. It is possible to use :class:`.IQMDevice` class directly, but
-certain devices with predefined metadata are also available as subclasses of :class:`.IQMDevice`. As an example, let
-us import the class :class:`.Adonis`, which describes IQM's five-qubit architecture and view some of its properties
-contained in the :meth:`.Adonis.metadata` property:
+:attr:`.IQMDevice.metadata` property. It is possible to use the IQMDevice class directly, but
+certain devices with predefined metadata are also available as subclasses of IQMDevice. As an example, let
+us import the class :class:`.Adonis`, which describes IQM's five-qubit architecture, and view some of its
+properties contained in its ``metadata`` property:
 
 .. code-block:: python
 
@@ -48,7 +48,7 @@ contained in the :meth:`.Adonis.metadata` property:
 
 IQM devices use :class:`cirq.NamedQubit` to represent their qubits. The names of the qubits consist of a prefix
 followed by a numeric index, so we have qubit names like ``QB1``, ``QB2``, etc. Note that we use 1-based
-indexing. You can get the list of the qubits in a particular device by accessing the ``qubits`` attribute of a
+indexing. You can get the list of the qubits in a particular device by accessing the :attr:`qubits` attribute of a
 corresponding :class:`.IQMDevice` instance:
 
 .. code-block:: python
@@ -224,7 +224,7 @@ instance and use its :meth:`~.IQMSampler.run` method to send a circuit for execu
 
 Note that the code snippet above assumes that you have set the variable ``iqm_server_url`` to the URL
 of the IQM server. By default, the latest calibration set is used for running the circuit. If you want to use
-a particular calibration set, provide a ``calibration_set_id`` integer argument. The sampler will by default use an
+a particular calibration set, provide the ``calibration_set_id`` argument. The sampler will by default use an
 :class:`.IQMDevice` created based on architecture data obtained from the server, which is then available in the
 :meth:`.IQMSampler.device` property. Alternatively, the device can be specified directly with the ``device`` argument.
 
@@ -234,7 +234,7 @@ then set the ``IQM_TOKENS_FILE`` environment variable to use those tokens.
 See Cortex CLI's `documentation <https://iqm-finland.github.io/cortex-cli/readme.html>`_ for details.
 Alternatively, authorize with the IQM_AUTH_SERVER, IQM_AUTH_USERNAME and IQM_AUTH_PASSWORD environment variables
 or pass them as arguments to the constructor of :class:`.IQMProvider`, however this approach is less secure
-and considered as deprecated.
+and considered deprecated.
 
 When executing a circuit that uses something other than the device qubits, you need to either route it first
 as explained in :ref:`workflow 1 <workflow_1>` above,

--- a/examples/usage.ipynb
+++ b/examples/usage.ipynb
@@ -30,17 +30,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "adonis = Adonis()\n",
     "print(adonis.__doc__)\n",
-    "print(adonis.NATIVE_GATES)\n",
-    "print(adonis.NATIVE_GATE_INSTANCES)\n",
+    "print(adonis.metadata.gateset)\n",
     "print(adonis.qubits)"
    ]
   },
@@ -56,11 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "a, b, c = adonis.qubits[:3]\n",
@@ -103,11 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "circuit = cirq.Circuit([\n",
@@ -155,11 +142,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "Note that the above output vector represents the state before the measurement in the optimized circuit, not the original one, which would have the same phase for both terms. `simplify_circuit` has eliminated a `ZPowGate` which has no effect on the measurement.\n",
     "\n",
@@ -269,17 +252,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "scrolled": true
    },
    "outputs": [],
    "source": [
     "apollo = Apollo()\n",
     "print(apollo.__doc__)\n",
-    "print(apollo.NATIVE_GATES)\n",
-    "print(apollo.NATIVE_GATE_INSTANCES)\n",
+    "print(apollo.gateset)\n",
     "print(apollo.qubits)"
    ]
   },

--- a/examples/usage.ipynb
+++ b/examples/usage.ipynb
@@ -258,7 +258,7 @@
    "source": [
     "apollo = Apollo()\n",
     "print(apollo.__doc__)\n",
-    "print(apollo.gateset)\n",
+    "print(apollo.metadata.gateset)\n",
     "print(apollo.qubits)"
    ]
   },

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     numpy
     cirq ~= 1.0
     ply  # required by cirq.contrib.qasm_import
-    iqm-client >= 8.0, < 10.0
+    iqm-client >= 9.0, < 10.0
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = ~= 3.9

--- a/src/cirq_iqm/devices/__init__.py
+++ b/src/cirq_iqm/devices/__init__.py
@@ -17,4 +17,5 @@
 from .adonis import Adonis
 from .apollo import Apollo
 from .iqm_device import IQMDevice
+from .iqm_device_metadata import IQMDeviceMetadata
 from .valkmusa import Valkmusa

--- a/src/cirq_iqm/devices/adonis.py
+++ b/src/cirq_iqm/devices/adonis.py
@@ -16,7 +16,7 @@ IQM's Adonis quantum architecture.
 """
 from __future__ import annotations
 
-from .iqm_device import IQMDevice
+from .iqm_device import IQMDevice, IQMDeviceMetadata
 
 
 class Adonis(IQMDevice):
@@ -38,6 +38,7 @@ class Adonis(IQMDevice):
     the circuit.
     """
 
-    QUBIT_COUNT = 5
-
-    CONNECTIVITY = ({1, 3}, {2, 3}, {4, 3}, {5, 3})
+    def __init__(self):
+        qubits = self._qubit_set_from_count(5)
+        connectivity = ({1, 3}, {2, 3}, {4, 3}, {5, 3})
+        super().__init__(IQMDeviceMetadata(qubits, connectivity))

--- a/src/cirq_iqm/devices/adonis.py
+++ b/src/cirq_iqm/devices/adonis.py
@@ -39,6 +39,6 @@ class Adonis(IQMDevice):
     """
 
     def __init__(self):
-        qubits = self._qubit_set_from_count(5)
+        qubit_count = 5
         connectivity = ({1, 3}, {2, 3}, {4, 3}, {5, 3})
-        super().__init__(IQMDeviceMetadata(qubits, connectivity))
+        super().__init__(IQMDeviceMetadata.from_qubit_indices(qubit_count, connectivity))

--- a/src/cirq_iqm/devices/apollo.py
+++ b/src/cirq_iqm/devices/apollo.py
@@ -47,7 +47,7 @@ class Apollo(IQMDevice):
     """
 
     def __init__(self):
-        qubits = self._qubit_set_from_count(20)
+        qubit_count = 20
         connectivity = (
             {1, 2},
             {1, 4},
@@ -80,4 +80,4 @@ class Apollo(IQMDevice):
             {18, 19},
             {19, 20},
         )
-        super().__init__(IQMDeviceMetadata(qubits, connectivity))
+        super().__init__(IQMDeviceMetadata.from_qubit_indices(qubit_count, connectivity))

--- a/src/cirq_iqm/devices/apollo.py
+++ b/src/cirq_iqm/devices/apollo.py
@@ -16,7 +16,7 @@ IQM's Apollo quantum architecture.
 """
 from __future__ import annotations
 
-from .iqm_device import IQMDevice
+from .iqm_device import IQMDevice, IQMDeviceMetadata
 
 
 class Apollo(IQMDevice):
@@ -46,37 +46,38 @@ class Apollo(IQMDevice):
     the circuit.
     """
 
-    QUBIT_COUNT = 20
-
-    CONNECTIVITY = (
-        {1, 2},
-        {1, 4},
-        {2, 5},
-        {3, 4},
-        {3, 8},
-        {4, 5},
-        {4, 9},
-        {5, 6},
-        {5, 10},
-        {6, 7},
-        {6, 11},
-        {7, 12},
-        {8, 9},
-        {8, 13},
-        {9, 10},
-        {9, 14},
-        {10, 11},
-        {10, 15},
-        {11, 12},
-        {11, 16},
-        {12, 17},
-        {13, 14},
-        {14, 15},
-        {14, 18},
-        {15, 16},
-        {15, 19},
-        {16, 17},
-        {16, 20},
-        {18, 19},
-        {19, 20},
-    )
+    def __init__(self):
+        qubits = self._qubit_set_from_count(20)
+        connectivity = (
+            {1, 2},
+            {1, 4},
+            {2, 5},
+            {3, 4},
+            {3, 8},
+            {4, 5},
+            {4, 9},
+            {5, 6},
+            {5, 10},
+            {6, 7},
+            {6, 11},
+            {7, 12},
+            {8, 9},
+            {8, 13},
+            {9, 10},
+            {9, 14},
+            {10, 11},
+            {10, 15},
+            {11, 12},
+            {11, 16},
+            {12, 17},
+            {13, 14},
+            {14, 15},
+            {14, 18},
+            {15, 16},
+            {15, 19},
+            {16, 17},
+            {16, 20},
+            {18, 19},
+            {19, 20},
+        )
+        super().__init__(IQMDeviceMetadata(qubits, connectivity))

--- a/src/cirq_iqm/devices/iqm_device.py
+++ b/src/cirq_iqm/devices/iqm_device.py
@@ -262,9 +262,5 @@ class IQMDevice(devices.Device):
 
         self.check_qubit_connectivity(operation)
 
-    @staticmethod
-    def _qubit_set_from_count(qubit_count: int) -> frozenset[cirq.NamedQubit]:
-        return frozenset(cirq.NamedQubit.range(1, qubit_count + 1, prefix=IQMDeviceMetadata.QUBIT_NAME_PREFIX))
-
     def __eq__(self, other):
         return self.__class__ == other.__class__ and self._metadata == other._metadata

--- a/src/cirq_iqm/devices/iqm_device.py
+++ b/src/cirq_iqm/devices/iqm_device.py
@@ -22,12 +22,14 @@ from __future__ import annotations
 
 import collections.abc as ca
 from math import pi as PI
-from typing import Optional, Union
+from typing import FrozenSet, Optional, Union
 import uuid
 
 import cirq
 from cirq import InsertStrategy, MeasurementGate, devices, ops, protocols
-from cirq.contrib.routing.router import nx, route_circuit
+from cirq.contrib.routing.router import route_circuit
+
+from .iqm_device_metadata import IQMDeviceMetadata
 
 
 def _verify_unique_measurement_keys(operations: ca.Iterable[cirq.Operation]) -> None:
@@ -51,48 +53,41 @@ class IQMDevice(devices.Device):
 
     Adds extra functionality on top of the basic :class:`cirq.Device` class for decomposing gates,
     optimizing circuits and mapping qubits.
+
+    Args:
+        metadata: device metadata which contains the qubits, their connectivity, and the native gateset
     """
 
-    QUBIT_COUNT: Optional[int] = None
-    """number of qubits on the device"""
+    def __init__(self, metadata: IQMDeviceMetadata):
+        self._metadata = metadata
+        self.qubits = tuple(sorted(self._metadata.qubit_set))
 
-    QUBIT_NAME_PREFIX: str = 'QB'
-    """prefix for qubit names, to be followed by their numerical index"""
-
-    CONNECTIVITY: tuple[set[int], ...] = ()
-    """qubit connectivity graph of the device"""
-
-    NATIVE_GATES: tuple[type[cirq.Gate], ...] = (ops.PhasedXPowGate, ops.XPowGate, ops.YPowGate, ops.MeasurementGate)
-    """native gate set of the device (gate families)"""
-
-    NATIVE_GATE_INSTANCES: tuple[cirq.Gate, ...] = (ops.CZPowGate(),)
-    """native gate set of the device (individual gates)"""
-
-    def __init__(self):
-        self.qubits = tuple(cirq.NamedQubit.range(1, self.QUBIT_COUNT + 1, prefix=self.QUBIT_NAME_PREFIX))
+    @property
+    def metadata(self) -> IQMDeviceMetadata:
+        """Returns metadata for the device."""
+        return self._metadata
 
     @classmethod
     def get_qubit_index(cls, qubit: cirq.NamedQubit) -> int:
         """The numeric index of the given qubit on the device."""
-        return int(qubit.name[len(cls.QUBIT_NAME_PREFIX) :])
+        return int(qubit.name[len(IQMDeviceMetadata.QUBIT_NAME_PREFIX) :])
 
     def get_qubit(self, index: int) -> cirq.NamedQubit:
         """The device qubit corresponding to the given numeric index."""
         return self.qubits[index - 1]  # 1-based indexing
 
-    @classmethod
-    def check_qubit_connectivity(cls, operation: cirq.Operation) -> None:
+    def check_qubit_connectivity(self, operation: cirq.Operation) -> None:
         """Raises a ValueError if operation acts on qubits that are not connected."""
         if len(operation.qubits) >= 2 and not isinstance(operation.gate, ops.MeasurementGate):
-            connection = set(cls.get_qubit_index(q) for q in operation.qubits)  # type: ignore
-            if connection not in cls.CONNECTIVITY:
+            if operation.qubits not in self._metadata.nx_graph.edges:
                 raise ValueError(f'Unsupported qubit connectivity required for {operation!r}')
 
-    @classmethod
-    def is_native_operation(cls, op: cirq.Operation) -> bool:
+    def is_native_operation(self, op: cirq.Operation) -> bool:
         """Predicate, True iff the given operation is considered native for the architecture."""
-        return isinstance(op, (ops.GateOperation, ops.TaggedOperation)) and (
-            isinstance(op.gate, cls.NATIVE_GATES) or op.gate in cls.NATIVE_GATE_INSTANCES
+        return (
+            isinstance(op, (ops.GateOperation, ops.TaggedOperation))
+            and (op.gate is not None)
+            and (op.gate in self._metadata.gateset)
         )
 
     def operation_decomposer(self, op: cirq.Operation) -> Optional[list[cirq.Operation]]:
@@ -199,8 +194,6 @@ class IQMDevice(devices.Device):
         """
         _validate_for_routing(circuit)
 
-        device_graph = nx.Graph(tuple(map(self.get_qubit, edge)) for edge in self.CONNECTIVITY)
-
         # Remove all measurement gates and replace them with 1-qubit identity gates so they don't
         # disappear from the final swap network if no other operations remain. We will add them back after routing the
         # rest of the network. This is done for two purposes: it allows the circuit to contain measurements of more than
@@ -215,7 +208,7 @@ class IQMDevice(devices.Device):
             modified_circuit.append(cirq.I(q).with_tags(i_tag))
 
         # Route the modified circuit.
-        swap_network = route_circuit(modified_circuit, device_graph, algo_name='greedy')
+        swap_network = route_circuit(modified_circuit, self._metadata.nx_graph, algo_name='greedy')
 
         # Return measurements to the circuit with potential qubit swaps.
         final_qubit_mapping = {v: k for k, v in swap_network.final_mapping().items()}
@@ -269,5 +262,9 @@ class IQMDevice(devices.Device):
 
         self.check_qubit_connectivity(operation)
 
+    @staticmethod
+    def _qubit_set_from_count(qubit_count: int) -> FrozenSet[cirq.NamedQubit]:
+        return frozenset(cirq.NamedQubit.range(1, qubit_count + 1, prefix=IQMDeviceMetadata.QUBIT_NAME_PREFIX))
+
     def __eq__(self, other):
-        return self.__class__ == other.__class__
+        return self.__class__ == other.__class__ and self._metadata == other._metadata

--- a/src/cirq_iqm/devices/iqm_device.py
+++ b/src/cirq_iqm/devices/iqm_device.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import collections.abc as ca
 from math import pi as PI
-from typing import FrozenSet, Optional, Union
+from typing import Optional, Union
 import uuid
 
 import cirq
@@ -263,7 +263,7 @@ class IQMDevice(devices.Device):
         self.check_qubit_connectivity(operation)
 
     @staticmethod
-    def _qubit_set_from_count(qubit_count: int) -> FrozenSet[cirq.NamedQubit]:
+    def _qubit_set_from_count(qubit_count: int) -> frozenset[cirq.NamedQubit]:
         return frozenset(cirq.NamedQubit.range(1, qubit_count + 1, prefix=IQMDeviceMetadata.QUBIT_NAME_PREFIX))
 
     def __eq__(self, other):

--- a/src/cirq_iqm/devices/iqm_device.py
+++ b/src/cirq_iqm/devices/iqm_device.py
@@ -72,7 +72,7 @@ class IQMDevice(devices.Device):
         """The numeric index of the given qubit on the device."""
         return int(qubit.name[len(IQMDeviceMetadata.QUBIT_NAME_PREFIX) :])
 
-    def get_qubit(self, index: int) -> cirq.NamedQubit:
+    def get_qubit(self, index: int) -> cirq.Qid:
         """The device qubit corresponding to the given numeric index."""
         return self.qubits[index - 1]  # 1-based indexing
 

--- a/src/cirq_iqm/devices/iqm_device_metadata.py
+++ b/src/cirq_iqm/devices/iqm_device_metadata.py
@@ -70,21 +70,21 @@ class IQMDeviceMetadata(devices.DeviceMetadata):
     @classmethod
     def from_architecture(cls, architecture: QuantumArchitectureSpecification) -> IQMDeviceMetadata:
         """Returns device metadata object created based on architecture specification"""
-        qubits = frozenset(NamedQubit(qb) for qb in architecture.qubits)
-        connectivity = tuple({NamedQubit(qb) for qb in edge} for edge in architecture.qubit_connectivity)
+        qubits = tuple(NamedQubit(qb) for qb in architecture.qubits)
+        connectivity = tuple(tuple(NamedQubit(qb) for qb in edge) for edge in architecture.qubit_connectivity)
         gateset = cirq.Gateset(*(cirq_op for iqm_op in architecture.operations for cirq_op in _IQM_CIRQ_OP_MAP[iqm_op]))
-        return IQMDeviceMetadata(qubits, connectivity, gateset)
+        return cls(qubits, connectivity, gateset)
 
     @classmethod
     def from_qubit_indices(
         cls, qubit_count: int, connectivity_indices: tuple[set[int], ...], gateset: Optional[cirq.Gateset] = None
     ) -> IQMDeviceMetadata:
         """Returns device metadata object created based on connectivity specified using qubit indices only."""
-        qubits = frozenset(NamedQubit.range(1, qubit_count + 1, prefix=IQMDeviceMetadata.QUBIT_NAME_PREFIX))
+        qubits = tuple(NamedQubit.range(1, qubit_count + 1, prefix=cls.QUBIT_NAME_PREFIX))
         connectivity = tuple(
-            {NamedQubit(f'{IQMDeviceMetadata.QUBIT_NAME_PREFIX}{qb}') for qb in edge} for edge in connectivity_indices
+            tuple(NamedQubit(f'{cls.QUBIT_NAME_PREFIX}{qb}') for qb in edge) for edge in connectivity_indices
         )
-        return IQMDeviceMetadata(qubits, connectivity, gateset)
+        return cls(qubits, connectivity, gateset)
 
     @property
     def qubit_set(self) -> frozenset[NamedQubit]:

--- a/src/cirq_iqm/devices/iqm_device_metadata.py
+++ b/src/cirq_iqm/devices/iqm_device_metadata.py
@@ -14,7 +14,8 @@
 """DeviceMetadata subtype for IQM devices."""
 from __future__ import annotations
 
-from typing import Iterable, Optional, Union
+from collections.abc import Iterable
+from typing import Optional, Union
 
 import cirq
 from cirq import NamedQubit, Qid, devices, ops
@@ -91,8 +92,4 @@ class IQMDeviceMetadata(devices.DeviceMetadata):
         return self._gateset
 
     def _value_equality_values_(self):
-        graph_equality = (
-            tuple(sorted(self._nx_graph.nodes())),
-            tuple(sorted(self._nx_graph.edges(data='directed'))),
-        )
-        return self._qubits_set, graph_equality, self._gateset
+        return *super()._value_equality_values_(), self._gateset

--- a/src/cirq_iqm/devices/iqm_device_metadata.py
+++ b/src/cirq_iqm/devices/iqm_device_metadata.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Iterable, Optional, Union
 
 import cirq
-from cirq import NamedQubit, devices, ops
+from cirq import NamedQubit, Qid, devices, ops
 from cirq.contrib.routing.router import nx
 from iqm_client import QuantumArchitectureSpecification
 
@@ -45,10 +45,10 @@ class IQMDeviceMetadata(devices.DeviceMetadata):
     QUBIT_NAME_PREFIX: str = 'QB'
     """prefix for qubit names, to be followed by their numerical index"""
 
-    def __init__(  # pylint: disable=super-init-not-called
+    def __init__(
         self,
-        qubits: Iterable[NamedQubit],
-        connectivity: Iterable[Iterable[NamedQubit]],
+        qubits: Iterable[Qid],
+        connectivity: Iterable[Iterable[Qid]],
         gateset: Optional[cirq.Gateset] = None,
     ):
         """Construct an IQMDeviceMetadata object."""
@@ -56,8 +56,7 @@ class IQMDeviceMetadata(devices.DeviceMetadata):
         for edge in connectivity:
             edge_qubits = list(edge)
             nx_graph.add_edge(edge_qubits[0], edge_qubits[1])
-        self._qubits_set: frozenset[NamedQubit] = frozenset(qubits)
-        self._nx_graph = nx_graph
+        super().__init__(qubits, nx_graph)
 
         if gateset is None:
             # default gateset for IQM devices
@@ -85,11 +84,6 @@ class IQMDeviceMetadata(devices.DeviceMetadata):
             tuple(NamedQubit(f'{cls.QUBIT_NAME_PREFIX}{qb}') for qb in edge) for edge in connectivity_indices
         )
         return cls(qubits, connectivity, gateset)
-
-    @property
-    def qubit_set(self) -> frozenset[NamedQubit]:
-        """Returns the set of qubits on the device."""
-        return self._qubits_set
 
     @property
     def gateset(self) -> cirq.Gateset:

--- a/src/cirq_iqm/devices/iqm_device_metadata.py
+++ b/src/cirq_iqm/devices/iqm_device_metadata.py
@@ -1,0 +1,73 @@
+# Copyright 2020–2022 Cirq on IQM developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""DeviceMetadata subtype for IQM devices."""
+
+from typing import FrozenSet, Optional
+
+import cirq
+from cirq import NamedQubit, devices, ops
+from cirq.contrib.routing.router import nx
+
+
+@cirq.value.value_equality
+class IQMDeviceMetadata(devices.DeviceMetadata):
+    """Hardware metadata for IQM devices.
+
+    Args:
+        qubits: frozenset of qubits that exist on the device
+        connectivity: qubit connectivity graph of the device
+        gateset: Native gateset of the device. If None, a default IQM device gateset will be used.
+    """
+
+    QUBIT_NAME_PREFIX: str = 'QB'
+    """prefix for qubit names, to be followed by their numerical index"""
+
+    def __init__(  # pylint: disable=super-init-not-called
+        self,
+        qubits: FrozenSet[cirq.NamedQubit],
+        connectivity: tuple[set[int], ...],
+        gateset: Optional[cirq.Gateset] = None,
+    ):
+        """Construct an IQMDeviceMetadata object."""
+        nx_graph = nx.Graph()
+        for edge in connectivity:
+            edge_qubits = [NamedQubit(f'{self.QUBIT_NAME_PREFIX}{q}') for q in edge]
+            nx_graph.add_edge(edge_qubits[0], edge_qubits[1])
+        self._qubits_set: FrozenSet[cirq.NamedQubit] = frozenset(qubits)
+        self._nx_graph = nx_graph
+
+        if gateset is None:
+            # default gateset for IQM devices
+            self._gateset = cirq.Gateset(
+                ops.PhasedXPowGate, ops.XPowGate, ops.YPowGate, ops.MeasurementGate, ops.CZPowGate()
+            )
+        else:
+            self._gateset = gateset
+
+    @property
+    def qubit_set(self) -> FrozenSet[cirq.NamedQubit]:
+        """Returns the set of qubits on the device."""
+        return self._qubits_set
+
+    @property
+    def gateset(self) -> cirq.Gateset:
+        """Returns the ``cirq.Gateset`` of supported gates on this device."""
+        return self._gateset
+
+    def _value_equality_values_(self):
+        graph_equality = (
+            tuple(sorted(self._nx_graph.nodes())),
+            tuple(sorted(self._nx_graph.edges(data='directed'))),
+        )
+        return self._qubits_set, graph_equality, self._gateset

--- a/src/cirq_iqm/devices/valkmusa.py
+++ b/src/cirq_iqm/devices/valkmusa.py
@@ -17,9 +17,10 @@ IQM's Valkmusa quantum architecture.
 from math import pi as PI
 from typing import Optional
 
+import cirq
 from cirq import ops
 
-from .iqm_device import IQMDevice
+from .iqm_device import IQMDevice, IQMDeviceMetadata
 
 PI_2 = PI / 2
 
@@ -44,21 +45,19 @@ class Valkmusa(IQMDevice):
     The qubits are always measured simultaneously at the end of the computation.
     """
 
-    QUBIT_COUNT = 2
-
-    CONNECTIVITY = ({1, 2},)
-
-    NATIVE_GATES = (
-        ops.PhasedXPowGate,
-        # XPow and YPow kept for convenience, Cirq does not know how to decompose them into PhasedX
-        # so we would have to add those rules...
-        ops.XPowGate,
-        ops.YPowGate,
-        ops.ISwapPowGate,
-        ops.MeasurementGate,
-    )
-
-    NATIVE_GATE_INSTANCES = ()
+    def __init__(self):
+        qubits = self._qubit_set_from_count(2)
+        connectivity = ({1, 2},)
+        gateset = cirq.Gateset(
+            ops.PhasedXPowGate,
+            # XPow and YPow kept for convenience, Cirq does not know how to decompose them into PhasedX
+            # so we would have to add those rules...
+            ops.XPowGate,
+            ops.YPowGate,
+            ops.ISwapPowGate,
+            ops.MeasurementGate,
+        )
+        super().__init__(IQMDeviceMetadata(qubits, connectivity, gateset))
 
     def operation_decomposer(self, op: ops.Operation) -> Optional[list[ops.Operation]]:
         # Decomposes CNOT and the CZPowGate family to Valkmusa native gates.

--- a/src/cirq_iqm/devices/valkmusa.py
+++ b/src/cirq_iqm/devices/valkmusa.py
@@ -46,7 +46,7 @@ class Valkmusa(IQMDevice):
     """
 
     def __init__(self):
-        qubits = self._qubit_set_from_count(2)
+        qubit_count = 2
         connectivity = ({1, 2},)
         gateset = cirq.Gateset(
             ops.PhasedXPowGate,
@@ -57,7 +57,7 @@ class Valkmusa(IQMDevice):
             ops.ISwapPowGate,
             ops.MeasurementGate,
         )
-        super().__init__(IQMDeviceMetadata(qubits, connectivity, gateset))
+        super().__init__(IQMDeviceMetadata.from_qubit_indices(qubit_count, connectivity, gateset))
 
     def operation_decomposer(self, op: ops.Operation) -> Optional[list[ops.Operation]]:
         # Decomposes CNOT and the CZPowGate family to Valkmusa native gates.

--- a/src/cirq_iqm/iqm_sampler.py
+++ b/src/cirq_iqm/iqm_sampler.py
@@ -47,19 +47,20 @@ class IQMSampler(cirq.work.Sampler):
 
     Args:
         url: Endpoint for accessing the server interface. Has to start with http or https.
-        device: Device to execute the circuits on. If None, the device will be created based
-            on the quantum architecture obtained from IQMClient.
+        device: Device to execute the circuits on. If ``None``, the device will be created based
+            on the quantum architecture obtained from :class:`.IQMClient`.
+        qubit_mapping:
+            Mapping of logical qubit names to physical qubit names.
+            If ``None``, use the identity mapping.
+        calibration_set_id:
+            ID of the calibration set to use. If ``None``, use the latest one.
 
     Keyword Args:
-        qubit_mapping:
-            Mapping of logical qubit names to physical qubits
-        calibration_set_id:
-            ID of the calibration set to use instead of the latest one
-        auth_server_url: URL of user authentication server, if required by the IQM Cortex server.
+        auth_server_url (str): URL of user authentication server, if required by the IQM Cortex server.
             This can also be set in the IQM_AUTH_SERVER environment variable.
-        username: Username, if required by the IQM Cortex server.
+        username (str): Username, if required by the IQM Cortex server.
             This can also be set in the IQM_AUTH_USERNAME environment variable.
-        password: Password, if required by the IQM Cortex server.
+        password (str): Password, if required by the IQM Cortex server.
             This can also be set in the IQM_AUTH_PASSWORD environment variable.
     """
 

--- a/tests/test_adonis.py
+++ b/tests/test_adonis.py
@@ -164,12 +164,12 @@ class TestGateDecomposition:
     """Decomposing gates."""
 
     @staticmethod
-    def is_native(op_or_op_list) -> bool:
-        """True iff the op_list consists of native operations only."""
-        if Adonis.is_native_operation(op_or_op_list):
+    def is_native(adonis, op_or_op_list) -> bool:
+        """True iff the op_list consists of native operations of adonis only."""
+        if adonis.is_native_operation(op_or_op_list):
             return True
         for op in op_or_op_list:
-            if not Adonis.is_native_operation(op):
+            if not adonis.is_native_operation(op):
                 raise TypeError(f'Non-native operation: {op}')
         return True
 
@@ -185,7 +185,7 @@ class TestGateDecomposition:
         ):
             decomposition = adonis.decompose_operation(op)
             assert decomposition == op
-            assert TestGateDecomposition.is_native(decomposition)
+            assert TestGateDecomposition.is_native(adonis, decomposition)
 
     @pytest.mark.parametrize('gate', non_native_1q_gates)
     def test_non_native_single_qubit_gates(self, adonis, gate):
@@ -198,7 +198,7 @@ class TestGateDecomposition:
             gate.on(q1).with_tags('tag_baz'),
         ):
             decomposition = adonis.decompose_operation(op)
-            assert TestGateDecomposition.is_native(decomposition)
+            assert TestGateDecomposition.is_native(adonis, decomposition)
 
     @pytest.mark.parametrize('gate', native_2q_gates)
     def test_native_two_qubit_gate(self, adonis, gate):
@@ -212,7 +212,7 @@ class TestGateDecomposition:
         ):
             decomposition = adonis.decompose_operation(op)
             assert decomposition == op
-            assert TestGateDecomposition.is_native(decomposition)
+            assert TestGateDecomposition.is_native(adonis, decomposition)
 
     @pytest.mark.parametrize('gate', non_native_2q_gates)
     def test_non_native_two_qubit_gates(self, adonis, gate):
@@ -226,7 +226,7 @@ class TestGateDecomposition:
             gate.on(q2, q1),
         ):
             decomposition = adonis.decompose_operation(op)
-            assert TestGateDecomposition.is_native(decomposition)
+            assert TestGateDecomposition.is_native(adonis, decomposition)
 
             # matrix representations must match up to global phase
             U = cirq.Circuit(op)._unitary_()

--- a/tests/test_apollo.py
+++ b/tests/test_apollo.py
@@ -164,12 +164,12 @@ class TestGateDecomposition:
     """Decomposing gates."""
 
     @staticmethod
-    def is_native(op_or_op_list) -> bool:
-        """True iff the op_list consists of native operations only."""
-        if Apollo.is_native_operation(op_or_op_list):
+    def is_native(apollo, op_or_op_list) -> bool:
+        """True iff the op_list consists of native operations of apollo only."""
+        if apollo.is_native_operation(op_or_op_list):
             return True
         for op in op_or_op_list:
-            if not Apollo.is_native_operation(op):
+            if not apollo.is_native_operation(op):
                 raise TypeError(f'Non-native operation: {op}')
         return True
 
@@ -185,7 +185,7 @@ class TestGateDecomposition:
         ):
             decomposition = apollo.decompose_operation(op)
             assert decomposition == op
-            assert TestGateDecomposition.is_native(decomposition)
+            assert TestGateDecomposition.is_native(apollo, decomposition)
 
     @pytest.mark.parametrize('gate', non_native_1q_gates)
     def test_non_native_single_qubit_gates(self, apollo, gate):
@@ -198,7 +198,7 @@ class TestGateDecomposition:
             gate.on(q1).with_tags('tag_baz'),
         ):
             decomposition = apollo.decompose_operation(op)
-            assert TestGateDecomposition.is_native(decomposition)
+            assert TestGateDecomposition.is_native(apollo, decomposition)
 
     @pytest.mark.parametrize('gate', native_2q_gates)
     def test_native_two_qubit_gate(self, apollo, gate):
@@ -212,7 +212,7 @@ class TestGateDecomposition:
         ):
             decomposition = apollo.decompose_operation(op)
             assert decomposition == op
-            assert TestGateDecomposition.is_native(decomposition)
+            assert TestGateDecomposition.is_native(apollo, decomposition)
 
     @pytest.mark.parametrize('gate', non_native_2q_gates)
     def test_non_native_two_qubit_gates(self, apollo, gate):
@@ -226,7 +226,7 @@ class TestGateDecomposition:
             gate.on(q2, q1),
         ):
             decomposition = apollo.decompose_operation(op)
-            assert TestGateDecomposition.is_native(decomposition)
+            assert TestGateDecomposition.is_native(apollo, decomposition)
 
             # matrix representations must match up to global phase
             U = cirq.Circuit(op)._unitary_()

--- a/tests/test_iqm_device.py
+++ b/tests/test_iqm_device.py
@@ -17,10 +17,13 @@ from cirq_iqm import Adonis, Apollo, Valkmusa
 def test_equality_method():
     adonis_1 = Adonis()
     adonis_2 = Adonis()
+    adonis_3 = Adonis()
     apollo_1 = Apollo()
     apollo_2 = Apollo()
     valkmusa = Valkmusa()
+    adonis_3._metadata = valkmusa.metadata
 
     assert adonis_1 == adonis_2
     assert valkmusa != adonis_1
     assert apollo_1 == apollo_2
+    assert adonis_2 != adonis_3

--- a/tests/test_iqm_device_metadata.py
+++ b/tests/test_iqm_device_metadata.py
@@ -1,0 +1,36 @@
+# Copyright 2020–2022 Cirq on IQM developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cirq
+from iqm_client.iqm_client import QuantumArchitectureSpecification
+
+from cirq_iqm import IQMDeviceMetadata
+
+
+def test_device_metadata_from_architecture():
+    qa = {
+        'name': 'Valkmusa',
+        'operations': [
+            'phased_rx',
+            'measurement',
+        ],
+        'qubits': ['QB1', 'QB2'],
+        'qubit_connectivity': [
+            ['QB1', 'QB2'],
+        ],
+    }
+    metadata = IQMDeviceMetadata.from_architecture(QuantumArchitectureSpecification(**qa))
+    assert metadata.qubit_set == {cirq.NamedQubit('QB1'), cirq.NamedQubit('QB2')}
+    assert list(metadata.nx_graph.edges) == [(cirq.NamedQubit('QB1'), cirq.NamedQubit('QB2'))]
+    assert metadata.gateset == cirq.Gateset(cirq.PhasedXPowGate, cirq.XPowGate, cirq.YPowGate, cirq.MeasurementGate)

--- a/tests/test_iqm_device_metadata.py
+++ b/tests/test_iqm_device_metadata.py
@@ -32,5 +32,5 @@ def test_device_metadata_from_architecture():
     }
     metadata = IQMDeviceMetadata.from_architecture(QuantumArchitectureSpecification(**qa))
     assert metadata.qubit_set == {cirq.NamedQubit('QB1'), cirq.NamedQubit('QB2')}
-    assert list(metadata.nx_graph.edges) == [(cirq.NamedQubit('QB1'), cirq.NamedQubit('QB2'))]
+    assert [set(e) for e in metadata.nx_graph.edges] == [{cirq.NamedQubit('QB1'), cirq.NamedQubit('QB2')}]
     assert metadata.gateset == cirq.Gateset(cirq.PhasedXPowGate, cirq.XPowGate, cirq.YPowGate, cirq.MeasurementGate)

--- a/tests/test_iqm_sampler.py
+++ b/tests/test_iqm_sampler.py
@@ -155,4 +155,6 @@ def test_device_metadata_from_architecture(base_url):
         sampler = IQMSampler(base_url)
     assert sampler.device.metadata.qubit_set == {cirq.NamedQubit('QB1'), cirq.NamedQubit('QB2')}
     assert list(sampler.device.metadata.nx_graph.edges) == [(cirq.NamedQubit('QB1'), cirq.NamedQubit('QB2'))]
-    assert sampler.device.metadata.gateset == cirq.Gateset(cirq.PhasedXPowGate, cirq.MeasurementGate)
+    assert sampler.device.metadata.gateset == cirq.Gateset(
+        cirq.PhasedXPowGate, cirq.XPowGate, cirq.YPowGate, cirq.MeasurementGate
+    )

--- a/tests/test_iqm_sampler.py
+++ b/tests/test_iqm_sampler.py
@@ -14,7 +14,7 @@
 import uuid
 
 import cirq
-from iqm_client.iqm_client import Circuit, IQMClient, Metadata, QuantumArchitecture, RunResult, Status
+from iqm_client.iqm_client import Circuit, IQMClient, Metadata, RunResult, Status
 from mockito import ANY, mock, when
 import pytest
 import sympy
@@ -134,27 +134,3 @@ def test_close_client():
         sampler.close_client()
     except Exception as exc:  # pylint: disable=broad-except
         assert False, f'sampler created with credentials raised an exception {exc} on .close_client()'
-
-
-@pytest.mark.usefixtures('unstub')
-def test_device_metadata_from_architecture(base_url):
-    qa = {
-        'quantum_architecture': {
-            'name': 'Valkmusa',
-            'operations': [
-                'phased_rx',
-                'measurement',
-            ],
-            'qubits': ['QB1', 'QB2'],
-            'qubit_connectivity': [
-                ['QB1', 'QB2'],
-            ],
-        }
-    }
-    with when(IQMClient).get_quantum_architecture().thenReturn(QuantumArchitecture(**qa).quantum_architecture):
-        sampler = IQMSampler(base_url)
-    assert sampler.device.metadata.qubit_set == {cirq.NamedQubit('QB1'), cirq.NamedQubit('QB2')}
-    assert list(sampler.device.metadata.nx_graph.edges) == [(cirq.NamedQubit('QB1'), cirq.NamedQubit('QB2'))]
-    assert sampler.device.metadata.gateset == cirq.Gateset(
-        cirq.PhasedXPowGate, cirq.XPowGate, cirq.YPowGate, cirq.MeasurementGate
-    )

--- a/tests/test_valkmusa.py
+++ b/tests/test_valkmusa.py
@@ -133,12 +133,12 @@ class TestGateDecomposition:
     """Decomposing gates."""
 
     @staticmethod
-    def is_native(op_or_op_list) -> bool:
-        """True iff the op_list consists of native operations only."""
-        if Valkmusa.is_native_operation(op_or_op_list):
+    def is_native(valkmusa, op_or_op_list) -> bool:
+        """True iff the op_list consists of native operations of valkmusa only."""
+        if valkmusa.is_native_operation(op_or_op_list):
             return True
         for op in op_or_op_list:
-            if not Valkmusa.is_native_operation(op):
+            if not valkmusa.is_native_operation(op):
                 raise TypeError(f'Non-native operation: {op}')
         return True
 
@@ -154,7 +154,7 @@ class TestGateDecomposition:
         ):
             decomposition = valkmusa.decompose_operation(op)
             assert decomposition == op
-            assert TestGateDecomposition.is_native(decomposition)
+            assert TestGateDecomposition.is_native(valkmusa, decomposition)
 
     @pytest.mark.parametrize('gate', non_native_1q_gates)
     def test_non_native_single_qubit_gates(self, valkmusa, gate):
@@ -166,7 +166,7 @@ class TestGateDecomposition:
             gate.on(QB2).with_tags('tag_baz'),
         ):
             decomposition = valkmusa.decompose_operation(op)
-            assert TestGateDecomposition.is_native(decomposition)
+            assert TestGateDecomposition.is_native(valkmusa, decomposition)
 
     @pytest.mark.parametrize('gate', native_2q_gates)
     def test_native_two_qubit_gates(self, valkmusa, gate):
@@ -177,7 +177,7 @@ class TestGateDecomposition:
         op = gate(QB1, QB2)
         decomposition = valkmusa.decompose_operation(op)
         assert decomposition == op
-        assert TestGateDecomposition.is_native(decomposition)
+        assert TestGateDecomposition.is_native(valkmusa, decomposition)
 
     @pytest.mark.parametrize('gate', non_native_2q_gates)
     def test_non_native_two_qubit_gates(self, valkmusa, gate):
@@ -190,4 +190,4 @@ class TestGateDecomposition:
             gate(QB2, QB1).with_tags('tag_baz'),
         ):
             decomposition = valkmusa.decompose_operation(op)
-            assert TestGateDecomposition.is_native(decomposition)
+            assert TestGateDecomposition.is_native(valkmusa, decomposition)


### PR DESCRIPTION
* Qubit connectivity and native gateset of a device are now defined using DeviceMetadata instead of class attributes, to have an interface consistent with other cirq* devices.
* IQMSampler will now by default use quantum architecture obtained from IQMClient to build the device metadata