### PR TITLE
Fix multi version docs publication

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 11.2
+============
+
+* Build and publish docs for older versions fixes. `#103 <https://github.com/iqm-finland/cirq-on-iqm/pull/103>`_
+
 Version 11.1
 ============
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ dev =
     tox == 3.26.0
 docs =
     sphinx == 4.5.0
-    sphinx-multiversion-contrib == 0.2.11
+    sphinx-multiversion-contrib == 0.2.12
     sphinx-book-theme == 0.3.3
 testing =
     black == 22.10.0


### PR DESCRIPTION
The new version of sphinx-multiversion is not using symlinks approach for reducing docs size, which was incompatible with GitHub Actions.