### PR TITLE
Correct HardCodedInitialMapper usage in docs

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -186,7 +186,7 @@ It serves as the starting point of the routing:
 
 .. code-block:: python
 
-    initial_mapper = cirq.cirq.HardCodedInitialMapper({q1: adonis.qubits[2], q2: adonis.qubits[0]})
+    initial_mapper = cirq.HardCodedInitialMapper({q1: adonis.qubits[2], q2: adonis.qubits[0]})
     routed_circuit_2, _, _ = adonis.route_circuit(
         decomposed_circuit,
         initial_mapper=initial_mapper,


### PR DESCRIPTION
https://quantumai.google/reference/python/cirq/HardCodedInitialMapper

`initial_mapper = cirq.cirq.HardCodedInitialMapper({q1: adonis.qubits[2], q2: adonis.qubits[0]})` 

Should be 

`initial_mapper = cirq.HardCodedInitialMapper({q1: adonis.qubits[2], q2: adonis.qubits[0]})`