### PR TITLE
Add ability to abort submitted jobs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog
 =========
 
-Version 12.0
-============
+Version 11.11
+=============
 
 * Submitted job is aborted if the user interrupts the program while it is waiting for results. `#114 <https://github.com/iqm-finland/cirq-on-iqm/pull/114>`_
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 12.0
+============
+
+* Submitted job is aborted if the user interrupts the program while it is waiting for results. `#114 <https://github.com/iqm-finland/cirq-on-iqm/pull/114>`_
+
 Version 11.10
 =============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "numpy",
     "cirq ~= 1.1",
     "ply",  # Required by cirq.contrib.qasm_import
-    "iqm-client >= 12.5, < 13.0"
+    "iqm-client >= 13.0, < 14.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
If the user interrupts the program with ctrl-c or similar (which creates a KeyboardInterrupt) when a job has been submitted to the server and the client is waiting for results, the submitted job is aborted.