### PR TITLE
Add Advanced examples to Documentation 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 11.13
+=============
+
+* Add table of backend options to the User Guide. Add example of submitting batch of circuits to the user guide. `#117 <https://github.com/iqm-finland/cirq-on-iqm/pull/117>`_
+
 Version 11.12
 =============
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 Version 11.13
 =============
 
-* Add table of backend options to the user guide. Add example of submitting batch of circuits to the user guide. `#117 <https://github.com/iqm-finland/cirq-on-iqm/pull/117>`_
+* Add table of backend options and an example of submitting a batch of circuits to the user guide. `#117 <https://github.com/iqm-finland/cirq-on-iqm/pull/117>`_
 
 Version 11.12
 =============

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 Version 11.13
 =============
 
-* Add table of backend options to the User Guide. Add example of submitting batch of circuits to the user guide. `#117 <https://github.com/iqm-finland/cirq-on-iqm/pull/117>`_
+* Add table of backend options to the user guide. Add example of submitting batch of circuits to the user guide. `#117 <https://github.com/iqm-finland/cirq-on-iqm/pull/117>`_
 
 Version 11.12
 =============

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -262,21 +262,45 @@ instance and use its :meth:`~.IQMSampler.run` method to send a circuit for execu
 
 
 Note that the code snippet above assumes that you have set the variable ``iqm_server_url`` to the URL
-of the IQM server. By default, the latest calibration set is used for running the circuit. If you want to use
-a particular calibration set, provide the ``calibration_set_id`` argument. The sampler will by default use an
-:class:`.IQMDevice` created based on architecture data obtained from the server, which is then available in the
-:attr:`.IQMSampler.device` property. Alternatively, the device can be specified directly with the ``device`` argument.
+of the IQM server. Additionally, you can pass IQM backend specific options to the :class:`.IQMSampler` class. 
+The below table summarises the currently available options:
 
-If any circuit in a job would take too long to execute compared to the coherence time of the QPU, the server will
-disqualify the job and not execute any circuits. In some special cases, you may want to disable this as follows:
+
+.. list-table::
+   :widths: 25 20 25 100
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Example value
+     - Description
+   * - `calibration_set_id`
+     - str
+     - "f7d9642e-b0ca-4f2d-af2a-30195bd7a76d"
+     - Indicates the calibration set to use. Defaults to `None`, which means the IQM server will use the best
+       available calibration set automatically.
+   * - `circuit_duration_check`
+     - bool
+     - False
+     - Enable or disable server-side circuit duration checks. The default value is `True`, which means if any job is
+       estimated to take unreasonably long compared to the coherence times of the qubits, or too long in wall-clock
+       time, the server will reject it. This option can be used to disable this behaviour. In normal use, the
+       circuit duration check should always remain enabled.
+   * - `heralding_mode`
+     - :py:class:`~iqm_client.iqm_client.HeraldingMode`
+     - "zeros"
+     - Heralding mode to use during execution. The default value is "none".
+
+For example if you would like to use a particular calibration set, you can provide it as follows:
 
 .. code-block:: python
 
-   result = sampler.run(circuit, repetitions=10, circuit_duration_check=False)
+   sampler = IQMSampler(iqm_server_url, calibration_set_id="f7d9642e-b0ca-4f2d-af2a-30195bd7a76d")
 
 
-Disabling the circuit duration check may be limited to certain users or groups, depending on the server settings.
-In normal use, the circuit duration check should always remain enabled.
+The same applies for `heralding_mode` and `circuit_duration_check`. The sampler will by default use an
+:class:`.IQMDevice` created based on architecture data obtained from the server, which is then available in the
+:attr:`.IQMSampler.device` property. Alternatively, the device can be specified directly with the ``device`` argument.
 
 If the IQM server you are connecting to requires authentication, you will also have to use
 `Cortex CLI <https://github.com/iqm-finland/cortex-cli>`_ to retrieve and automatically refresh access tokens,

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -290,8 +290,52 @@ When executing a circuit that uses something other than the device qubits, you n
 as explained in the :ref:`routing` section above.
 
 
-More examples
--------------
+More advanced examples
+----------------------
+
+In this section we demonstrate some of the more advanced examples of using Cirq on IQM and how you can use various tools available in Cirq.
+
+Multiple circuits can be submitted to the IQM quantum computer at once using the :meth:`~.IQMSampler.run_iqm_batch` method of :class:`.IQMSampler`. 
+
+.. code-block:: python
+   
+   circuit_list = []
+
+   circuit_list.append(routed_circuit_1)
+   circuit_list.append(routed_circuit_2)
+
+   results = sampler.run_iqm_batch(circuit_list, repetitions=10)
+
+   for result in results:
+        print(result.histogram(key="m"))
+
+
+Similiarly, parameterized circuits can be executed using :meth:`~.IQMSampler.run_sweep` and :meth:`~.cirq.resolve_parameters`.
+
+.. code-block:: python
+   
+   import sympy
+   q1, q2 = cirq.NamedQubit('Alice'), cirq.NamedQubit('Bob')
+   theta = sympy.Symbol("theta")
+   circuit = cirq.Circuit([
+    cirq.H(q1),
+    cirq.CNOT(q1, q2),
+    cirq.Z(q1) ** theta,
+    cirq.Z(q2) ** theta,
+    cirq.CNOT(q1, q2),
+    cirq.H(q1),
+    cirq.measure(q1, q2, key='m'),
+   ])
+
+   decomposed_circuit = adonis.decompose_circuit(circuit)
+   routed_circuit, _, _ = adonis.route_circuit(decomposed_circuit)
+   simplified_circuit = simplify_circuit(routed_circuit)
+
+   params = cirq.Linspace(key="theta", start=0, stop=0.5, length=3)
+   results = sampler.run_sweep(simplified_circuit, repetitions=10, params=params)
+   for result in results:
+       print(f'{result.params}: {result.histogram(key="m")}')
+
 
 More examples are available in the
 `examples directory <https://github.com/iqm-finland/cirq-on-iqm/tree/main/examples>`_

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -289,13 +289,8 @@ and ``IQM_AUTH_PASSWORD`` environment variables, or pass them as arguments to th
 When executing a circuit that uses something other than the device qubits, you need to route it first,
 as explained in the :ref:`routing` section above.
 
-
-More advanced examples
-----------------------
-
-In this section we demonstrate some of the more advanced examples of using Cirq on IQM and how you can use various tools available in Cirq.
-
 Multiple circuits can be submitted to the IQM quantum computer at once using the :meth:`~.IQMSampler.run_iqm_batch` method of :class:`.IQMSampler`. 
+This is often faster than executing the circuits individually. Circuits submitted in a batch are still executed sequentially.
 
 .. code-block:: python
    
@@ -310,32 +305,8 @@ Multiple circuits can be submitted to the IQM quantum computer at once using the
         print(result.histogram(key="m"))
 
 
-Similiarly, parameterized circuits can be executed using :meth:`~.IQMSampler.run_sweep` and :meth:`~.cirq.resolve_parameters`.
-
-.. code-block:: python
-   
-   import sympy
-   q1, q2 = cirq.NamedQubit('Alice'), cirq.NamedQubit('Bob')
-   theta = sympy.Symbol("theta")
-   circuit = cirq.Circuit([
-    cirq.H(q1),
-    cirq.CNOT(q1, q2),
-    cirq.Z(q1) ** theta,
-    cirq.Z(q2) ** theta,
-    cirq.CNOT(q1, q2),
-    cirq.H(q1),
-    cirq.measure(q1, q2, key='m'),
-   ])
-
-   decomposed_circuit = adonis.decompose_circuit(circuit)
-   routed_circuit, _, _ = adonis.route_circuit(decomposed_circuit)
-   simplified_circuit = simplify_circuit(routed_circuit)
-
-   params = cirq.Linspace(key="theta", start=0, stop=0.5, length=3)
-   results = sampler.run_sweep(simplified_circuit, repetitions=10, params=params)
-   for result in results:
-       print(f'{result.params}: {result.histogram(key="m")}')
-
+More examples
+-------------
 
 More examples are available in the
 `examples directory <https://github.com/iqm-finland/cirq-on-iqm/tree/main/examples>`_

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -289,7 +289,7 @@ The below table summarises the currently available options:
    * - `heralding_mode`
      - :py:class:`~iqm_client.iqm_client.HeraldingMode`
      - "zeros"
-     - Heralding mode to use during execution. The default value is "none".
+     - Heralding mode to use during execution. The default value is "none", "zeros" enables heralding.
 
 For example if you would like to use a particular calibration set, you can provide it as follows:
 


### PR DESCRIPTION
Hi, I would like to add 2 examples to the cirq-on-iqm docs: 
1. Batch submission with `IQMSampler.run_iqm_batch`
2. Parameterized submission using ` cirq.Linspace` + `IQMSampler.run_sweep`

I can also add these examples to the `examples` directory. 

I noticed that the documentation is somewhat formatted, however tox/black does not auto format it. Please also comment on the line lengths and how previous authors have kept it consistent. 

I would also like to add a table similar to https://iqm-finland.github.io/qiskit-on-iqm/user_guide.html#running-a-quantum-circuit-on-an-iqm-quantum-computer showing the different backend options. Why were these previously not added? They could be added for example under `Running on a real quantum computer`. 

Thanks!
