### PR TITLE
Remove Sphinx role :file:

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ corresponding tag, and running the docs builder. For example, to build the docum
     $ tox run -e docs
 
 ``tox run -e docs`` will build the documentation at ``./build/sphinx/html``. This command requires the ``tox,``, ``sphinx`` and 
-``sphinx-book-theme`` Python packages (see the ``docs`` optional dependency in `pyproject.toml`); 
+``sphinx-book-theme`` Python packages (see the ``docs`` optional dependency in ``pyproject.toml``); 
 you can install the necessary packages with ``pip install -e ".[dev,docs]"``
 
 

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ corresponding tag, and running the docs builder. For example, to build the docum
     $ tox run -e docs
 
 ``tox run -e docs`` will build the documentation at ``./build/sphinx/html``. This command requires the ``tox,``, ``sphinx`` and 
-``sphinx-book-theme`` Python packages (see the ``docs`` optional dependency in :file:`pyproject.toml`); 
+``sphinx-book-theme`` Python packages (see the ``docs`` optional dependency in `pyproject.toml`); 
 you can install the necessary packages with ``pip install -e ".[dev,docs]"``
 
 


### PR DESCRIPTION
PyPI does not allow Sphinx role :file: and rejects publishing attempt of the package