### PR TITLE
Disable failing pylint checks

### DIFF
--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -178,10 +178,10 @@ class TestSimplifyCircuit:
         assert len(new) == 2  # still 2 Moments
         # the ZPowGate preceding the measurement has been dropped
         assert len(tuple(new.all_operations())) == 3
-        op = new[0].operations[0]
+        op = new[0].operations[0]  # pylint: disable=no-member
         assert isinstance(op.gate, cirq.XPowGate)
         assert op.qubits == (q0,)
-        op = new[0].operations[1]
+        op = new[0].operations[1]  # pylint: disable=no-member
         assert isinstance(op.gate, cirq.ZPowGate)
         assert op.qubits == (q2,)
 
@@ -202,7 +202,7 @@ class TestSimplifyCircuit:
         assert len(new) == 2  # still 2 Moments
         # both ZPowGates were dropped
         assert len(tuple(new.all_operations())) == 2
-        op = new[0].operations[0]
+        op = new[0].operations[0]  # pylint: disable=no-member
         assert isinstance(op.gate, cirq.XPowGate)
         assert op.qubits == (q0,)
 

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -178,6 +178,10 @@ class TestSimplifyCircuit:
         assert len(new) == 2  # still 2 Moments
         # the ZPowGate preceding the measurement has been dropped
         assert len(tuple(new.all_operations())) == 3
+
+        # TODO: Re-enable pylint "no-member" checks once astroid
+        # bug [https://github.com/pylint-dev/astroid/issues/2448] is fixed
+
         op = new[0].operations[0]  # pylint: disable=no-member
         assert isinstance(op.gate, cirq.XPowGate)
         assert op.qubits == (q0,)


### PR DESCRIPTION
There has been a recent regression in astroid module (since version 3.2.0, most likely related to changes in igetattr method). It causes our CI workflows runs to fail, because pylint fails to infer the correct type of some variables.

astroid is a transitive dependency (pytest-pylint <- pylint <- astroid). Versions of transitive dependencies are not pinned in the project configuration, which allowed astroid regression to break the CI.

pylint checks should be re-enabled once astroid bug https://github.com/pylint-dev/astroid/issues/2448 gets fixed.
