### PR TITLE
Added Deneb-style transpiling support (requires iqm-client 18.0)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+Version 14.1
+============
+
+* Improved operation validation to check if it is calibrated according to the metadata rather than assuming.
+* Added IQMMoveGate class for Deneb architectures.
+* Updated IQMDevice class to support devices with resonators.
+
 Version 14.0
 ============
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,10 +5,10 @@ Changelog
 Version 14.2
 ============
 
-* Improved operation validation to check if it is calibrated according to the metadata rather than assuming.
-* Added IQMMoveGate class for Deneb architectures.
-* Updated IQMDevice class to support devices with resonators.
-* Require iqm-client >= 17.7. 
+* Improved operation validation to check if it is calibrated according to the metadata rather than assuming. `#133 <https://github.com/iqm-finland/cirq-on-iqm/pull/133>`_
+* Added IQMMoveGate class for Deneb architectures. `#133 <https://github.com/iqm-finland/cirq-on-iqm/pull/133>`_
+* Updated IQMDevice class to support devices with resonators. `#133 <https://github.com/iqm-finland/cirq-on-iqm/pull/133>`_
+* Require iqm-client >= 17.8. `#133 <https://github.com/iqm-finland/cirq-on-iqm/pull/133>`_
 
 Version 14.1
 ============

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -205,6 +205,9 @@ If you have gates involving more than two qubits you need to decompose them befo
 Since routing may add some SWAP gates to the circuit, you will need to decompose the circuit
 again after the routing, unless SWAP is a native gate for the target device.
 
+To ensure that the transpiler is restricted to a specific subset of qubits, you can provide a list of qubits in the ``qubit_subset`` argument such that ancillary qubits will not be added during routing. This is particularly useful when running Quantum Volume benchmarks.
+
+Additionally, if the target device supports MOVE gates (e.g. IQM Deneb), a final MOVE gate insertion step is performed. Under the hood, this uses the :meth:`transpile_insert_moves`method of the iqm_client library. This method is exposed through :meth:`transpile_insert_moves_into_circuit` which can also be used by advanced users to transpile circuits that have already some MOVE gates in them, or to remove existing MOVE gates from a circuit so the circuit can be reused on a device that does not support them. 
 
 Optimization
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "numpy",
     "cirq-core[contrib] ~= 1.2",
     "ply",  # Required by cirq.contrib.qasm_import
-    "iqm-client >= 17.8, < 18.0"
+    "iqm-client >= 18.0, < 19.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "numpy",
     "cirq-core[contrib] ~= 1.2",
     "ply",  # Required by cirq.contrib.qasm_import
-    "iqm-client >= 17.7, < 18.0"
+    "iqm-client >= 17.8, < 18.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "numpy",
     "cirq-core[contrib] ~= 1.2",
     "ply",  # Required by cirq.contrib.qasm_import
-    "iqm-client >= 17.6, < 18.0"
+    "iqm-client >= 17.7, < 18.0"
 ]
 
 [project.urls]

--- a/src/iqm/cirq_iqm/__init__.py
+++ b/src/iqm/cirq_iqm/__init__.py
@@ -25,3 +25,5 @@ except PackageNotFoundError:
     __version__ = 'unknown'
 finally:
     del version, PackageNotFoundError
+
+from .iqm_gates import *

--- a/src/iqm/cirq_iqm/__init__.py
+++ b/src/iqm/cirq_iqm/__init__.py
@@ -25,6 +25,6 @@ except PackageNotFoundError:
     __version__ = 'unknown'
 finally:
     del version, PackageNotFoundError
-
+# pylint: disable=wrong-import-position
 from .iqm_gates import *
 from .transpiler import transpile_insert_moves_into_circuit

--- a/src/iqm/cirq_iqm/__init__.py
+++ b/src/iqm/cirq_iqm/__init__.py
@@ -27,3 +27,4 @@ finally:
     del version, PackageNotFoundError
 
 from .iqm_gates import *
+from .transpiler import transpile_insert_moves_into_circuit

--- a/src/iqm/cirq_iqm/devices/iqm_device.py
+++ b/src/iqm/cirq_iqm/devices/iqm_device.py
@@ -60,6 +60,7 @@ class IQMDevice(devices.Device):
     def __init__(self, metadata: IQMDeviceMetadata):
         self._metadata = metadata
         self.qubits = tuple(sorted(self._metadata.qubit_set))
+        self.resonators = tuple(sorted(self._metadata.resonator_set))
 
     @property
     def metadata(self) -> IQMDeviceMetadata:
@@ -265,7 +266,7 @@ class IQMDevice(devices.Device):
             raise ValueError(f'Unsupported gate type: {operation.gate!r}')
 
         for qubit in operation.qubits:
-            if qubit not in self.qubits:
+            if qubit not in self.qubits and qubit not in self.resonators:
                 raise ValueError(f'Qubit not on device: {qubit!r}')
 
         self.check_qubit_connectivity(operation)

--- a/src/iqm/cirq_iqm/devices/iqm_device.py
+++ b/src/iqm/cirq_iqm/devices/iqm_device.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import collections.abc as ca
 from itertools import zip_longest
 from math import pi as PI
-from typing import Optional, cast
+from typing import Optional, cast, Sequence
 import uuid
 
 import cirq
@@ -202,6 +202,7 @@ class IQMDevice(devices.Device):
         circuit: cirq.Circuit,
         *,
         initial_mapper: Optional[cirq.AbstractInitialMapper] = None,
+        qubit_subset: Optional[Sequence[cirq.Qid]] = None,
     ) -> tuple[cirq.Circuit, dict[cirq.Qid, cirq.Qid], dict[cirq.Qid, cirq.Qid]]:
         """Routes the given circuit to the device connectivity and qubit names.
 
@@ -253,6 +254,9 @@ class IQMDevice(devices.Device):
         else:
             graph = self._metadata.nx_graph
             move_routing = False
+
+        if qubit_subset is not None:
+            graph = graph.subgraph(qubit_subset)
 
         # Route the modified circuit.
         router = cirq.RouteCQC(graph)

--- a/src/iqm/cirq_iqm/devices/iqm_device.py
+++ b/src/iqm/cirq_iqm/devices/iqm_device.py
@@ -23,12 +23,12 @@ from __future__ import annotations
 import collections.abc as ca
 from itertools import zip_longest
 from math import pi as PI
-from typing import Optional, cast, Sequence
+from typing import Optional, Sequence, cast
 import uuid
 
 import cirq
 from cirq import InsertStrategy, MeasurementGate, devices, ops, protocols
-import networkx as nx
+from cirq.contrib.routing.router import nx
 
 from iqm.cirq_iqm.iqm_gates import IQMMoveGate
 from iqm.cirq_iqm.transpiler import transpile_insert_moves_into_circuit
@@ -357,7 +357,7 @@ class IQMDevice(devices.Device):
         Returns:
             None if the IQMMoveGates are applied correctly.
         """
-        moves: dict[cirq.Qid, list[tuple[cirq.Qid, cirq.Qid]]] = {r: [] for r in self.resonators}
+        moves: dict[cirq.Qid, list[cirq.Qid]] = {r: [] for r in self.resonators}
         for moment in circuit:
             for operation in moment.operations:
                 if isinstance(operation.gate, IQMMoveGate):

--- a/src/iqm/cirq_iqm/devices/iqm_device.py
+++ b/src/iqm/cirq_iqm/devices/iqm_device.py
@@ -99,7 +99,7 @@ class IQMDevice(devices.Device):
         return check
 
     def has_valid_operation_targets(self, op: cirq.Operation) -> bool:
-        """Predicate, True iff the given operation is native and it=s targets are valid."""
+        """Predicate, True iff the given operation is native and its targets are valid."""
         matched_support = [
             (g, qbs)
             for g, qbs in self.supported_operations.items()
@@ -107,10 +107,12 @@ class IQMDevice(devices.Device):
         ]
         if len(matched_support) > 0:
             gf, valid_targets = matched_support[0]
+            valid_qubits = set(q for qb in valid_targets for q in qb)
             if gf == cirq.MeasurementGate:  # Measurements can be done on any available qubits
-                return all(q in [q for qb in valid_targets for q in qb] for q in op.qubits)
+                return all(q in valid_qubits for q in op.qubits)
             if issubclass(gf, cirq.InterchangeableQubitsGate):
-                return any(len(t) == len(op.qubits) and all(q1 in t for q1 in op.qubits) for t in valid_targets)
+                target_qubits = set(op.qubits)
+                return any(set(t) == target_qubits for t in valid_targets)
             return any(all(q1 == q2 for q1, q2 in zip_longest(op.qubits, t)) for t in valid_targets)
         return False
 

--- a/src/iqm/cirq_iqm/devices/iqm_device_metadata.py
+++ b/src/iqm/cirq_iqm/devices/iqm_device_metadata.py
@@ -76,17 +76,18 @@ class IQMDeviceMetadata(devices.DeviceMetadata):
                 gateset = cirq.Gateset(
                     ops.PhasedXPowGate, ops.XPowGate, ops.YPowGate, ops.MeasurementGate, ops.CZPowGate
                 )
+                qb_list: list[tuple[cirq.Qid, ...]] = [(qb,) for qb in qubits]
+                operations = {
+                    ops.PhasedXPowGate: qb_list,
+                    ops.XPowGate: qb_list,
+                    ops.YPowGate: qb_list,
+                    ops.MeasurementGate: qb_list,
+                    ops.CZPowGate: list(tuple(edge) for edge in connectivity),
+                }
             else:
                 gateset = cirq.Gateset(*operations.keys())
         self._gateset = gateset
 
-        if operations is None:
-            operations = {}
-            # for gate in [gf.gate() for gf in gateset.gates if not issubclass(gf.gate, ops.MeasurementGate)]:
-            #    if gate.num_qubits() == 1:
-            #        operations[gate] = [(q,) for q in qubits]
-            #    elif gate.num_qubits() == 2:
-            #        operations[gate] = [edge for edge in connectivity]
         self.operations = operations
 
     @property

--- a/src/iqm/cirq_iqm/devices/valkmusa.py
+++ b/src/iqm/cirq_iqm/devices/valkmusa.py
@@ -48,7 +48,7 @@ class Valkmusa(IQMDevice):
     def __init__(self):
         qubit_count = 2
         connectivity = ({1, 2},)
-        gateset = cirq.Gateset(
+        gateset = (
             ops.PhasedXPowGate,
             # XPow and YPow kept for convenience, Cirq does not know how to decompose them into PhasedX
             # so we would have to add those rules...

--- a/src/iqm/cirq_iqm/devices/valkmusa.py
+++ b/src/iqm/cirq_iqm/devices/valkmusa.py
@@ -17,10 +17,9 @@ IQM's Valkmusa quantum architecture.
 from math import pi as PI
 from typing import Optional
 
-import cirq
 from cirq import ops
 
-from .iqm_device import IQMDevice, IQMDeviceMetadata
+from iqm.cirq_iqm.devices import IQMDevice, IQMDeviceMetadata
 
 PI_2 = PI / 2
 

--- a/src/iqm/cirq_iqm/iqm_gates.py
+++ b/src/iqm/cirq_iqm/iqm_gates.py
@@ -14,10 +14,13 @@
 """ 
 Implementations for IQM specific quantum gates
 """
-from cirq import CircuitDiagramInfo, CircuitDiagramInfoArgs, ISwapPowGate, protocols
+from typing import List, Tuple
+
+from cirq import CircuitDiagramInfo, CircuitDiagramInfoArgs, EigenGate
+import numpy as np
 
 
-class IQMMoveGate(ISwapPowGate):
+class IQMMoveGate(EigenGate):
     r"""The MOVE operation is a unitary population exchange operation between a qubit and a resonator.
     Its effect is only defined in the invariant subspace :math:`S = \text{span}\{|00\rangle, |01\rangle, |10\rangle\}`,
     where it swaps the populations of the states :math:`|01\rangle` and :math:`|10\rangle`.
@@ -36,8 +39,26 @@ class IQMMoveGate(ISwapPowGate):
     Note: At this point the locus for the move gate must be defined in the order: ``[qubit, resonator]``.
     """
 
-    def __init__(self):
-        super().__init__()
+    def _num_qubits_(self) -> int:
+        return 2
+
+    def _eigen_components(self) -> List[Tuple[float, np.ndarray]]:
+        # yapf: disable
+        return [
+            (0, np.diag([1, 0, 0, 1])),
+            (+0.5, np.array([[0, 0, 0, 0],
+                             [0, 0.5, 0.5, 0],
+                             [0, 0.5, 0.5, 0],
+                             [0, 0, 0, 0]])),
+            (-0.5, np.array([[0, 0, 0, 0],
+                             [0, 0.5, -0.5, 0],
+                             [0, -0.5, 0.5, 0],
+                             [0, 0, 0, 0]])),
+        ]
+        # yapf: enable
 
     def _circuit_diagram_info_(self, args: CircuitDiagramInfoArgs) -> CircuitDiagramInfo:
-        return protocols.CircuitDiagramInfo(wire_symbols=('MOVE(QB)', 'MOVE(Res)'))
+        return CircuitDiagramInfo(wire_symbols=('MOVE(QB)', 'MOVE(Res)'), exponent=self._diagram_exponent(args))
+
+    def __str__(self) -> str:
+        return 'IQM Move'

--- a/src/iqm/cirq_iqm/iqm_gates.py
+++ b/src/iqm/cirq_iqm/iqm_gates.py
@@ -37,28 +37,21 @@ class IQMMoveGate(EigenGate):
     pair of MOVE operations.
 
     Note: At this point the locus for the move gate must be defined in the order: ``[qubit, resonator]``.
+    Additionally, the matrix representation of the gate set to be a SWAP gate, even though this is not what physically
+    happens.
     """
 
     def _num_qubits_(self) -> int:
         return 2
 
     def _eigen_components(self) -> List[Tuple[float, np.ndarray]]:
-        # yapf: disable
         return [
-            (0, np.diag([1, 0, 0, 1])),
-            (+0.5, np.array([[0, 0, 0, 0],
-                             [0, 0.5, 0.5, 0],
-                             [0, 0.5, 0.5, 0],
-                             [0, 0, 0, 0]])),
-            (-0.5, np.array([[0, 0, 0, 0],
-                             [0, 0.5, -0.5, 0],
-                             [0, -0.5, 0.5, 0],
-                             [0, 0, 0, 0]])),
+            (0, np.array([[1, 0, 0, 0], [0, 0.5, 0.5, 0], [0, 0.5, 0.5, 0], [0, 0, 0, 1]])),
+            (1, np.array([[0, 0, 0, 0], [0, 0.5, -0.5, 0], [0, -0.5, 0.5, 0], [0, 0, 0, 0]])),
         ]
-        # yapf: enable
 
     def _circuit_diagram_info_(self, args: CircuitDiagramInfoArgs) -> CircuitDiagramInfo:
         return CircuitDiagramInfo(wire_symbols=('MOVE(QB)', 'MOVE(Res)'), exponent=self._diagram_exponent(args))
 
     def __str__(self) -> str:
-        return 'IQM Move'
+        return 'MOVE'

--- a/src/iqm/cirq_iqm/iqm_gates.py
+++ b/src/iqm/cirq_iqm/iqm_gates.py
@@ -14,10 +14,11 @@
 """ 
 Implementations for IQM specific quantum gates
 """
-from cirq import protocols, ISwapPowGate
+from cirq import CircuitDiagramInfo, CircuitDiagramInfoArgs, ISwapPowGate, protocols
+
 
 class IQMMoveGate(ISwapPowGate):
-    """The MOVE operation is a unitary population exchange operation between a qubit and a resonator.
+    r"""The MOVE operation is a unitary population exchange operation between a qubit and a resonator.
     Its effect is only defined in the invariant subspace :math:`S = \text{span}\{|00\rangle, |01\rangle, |10\rangle\}`,
     where it swaps the populations of the states :math:`|01\rangle` and :math:`|10\rangle`.
     Its effect on the orthogonal subspace is undefined.
@@ -34,12 +35,9 @@ class IQMMoveGate(ISwapPowGate):
 
     Note: At this point the locus for the move gate must be defined in the order: ``[qubit, resonator]``.
     """
+
     def __init__(self):
         super().__init__()
 
-    def _circuit_diagram_info_(
-        self, args: 'cirq.CircuitDiagramInfoArgs'
-    ) -> 'cirq.CircuitDiagramInfo':
-        return protocols.CircuitDiagramInfo(
-            wire_symbols=('MOVE(QB)', 'MOVE(Res)')
-        )
+    def _circuit_diagram_info_(self, args: CircuitDiagramInfoArgs) -> CircuitDiagramInfo:
+        return protocols.CircuitDiagramInfo(wire_symbols=('MOVE(QB)', 'MOVE(Res)'))

--- a/src/iqm/cirq_iqm/iqm_gates.py
+++ b/src/iqm/cirq_iqm/iqm_gates.py
@@ -1,0 +1,45 @@
+# Copyright 2020–2022 Cirq on IQM developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" 
+Implementations for IQM specific quantum gates
+"""
+from cirq import protocols, ISwapPowGate
+
+class IQMMoveGate(ISwapPowGate):
+    """The MOVE operation is a unitary population exchange operation between a qubit and a resonator.
+    Its effect is only defined in the invariant subspace :math:`S = \text{span}\{|00\rangle, |01\rangle, |10\rangle\}`,
+    where it swaps the populations of the states :math:`|01\rangle` and :math:`|10\rangle`.
+    Its effect on the orthogonal subspace is undefined.
+
+    MOVE has the following presentation in the subspace :math:`S`:
+
+    .. math:: \text{MOVE}_S = |00\rangle \langle 00| + a |10\rangle \langle 01| + a^{-1} |01\rangle \langle 10|,
+
+    where :math:`a` is an undefined complex phase that is canceled when the MOVE gate is applied a second time.
+
+    To ensure that the state of the qubit and resonator has no overlap with :math:`|11\rangle`, it is
+    recommended that no single qubit gates are applied to the qubit in between a
+    pair of MOVE operations.
+
+    Note: At this point the locus for the move gate must be defined in the order: ``[qubit, resonator]``.
+    """
+    def __init__(self):
+        super().__init__()
+
+    def _circuit_diagram_info_(
+        self, args: 'cirq.CircuitDiagramInfoArgs'
+    ) -> 'cirq.CircuitDiagramInfo':
+        return protocols.CircuitDiagramInfo(
+            wire_symbols=('MOVE(QB)', 'MOVE(Res)')
+        )

--- a/src/iqm/cirq_iqm/iqm_operation_mapping.py
+++ b/src/iqm/cirq_iqm/iqm_operation_mapping.py
@@ -13,10 +13,50 @@
 # limitations under the License.
 """Logic for mapping Cirq Operations to the IQM transfer format.
 """
-from cirq.ops import CZPowGate, MeasurementGate, Operation, PhasedXPowGate, XPowGate, YPowGate
+from cirq import NamedQid
+from cirq.ops import CZPowGate, Gate, MeasurementGate, Operation, PhasedXPowGate, XPowGate, YPowGate
 
 from iqm.cirq_iqm.iqm_gates import IQMMoveGate
 from iqm.iqm_client import Instruction
+
+# Mapping from IQM operation names to cirq operations
+_IQM_CIRQ_OP_MAP: dict[str, tuple[type[Gate], ...]] = {
+    # XPow and YPow kept for convenience, Cirq does not know how to decompose them into PhasedX
+    # so we would have to add those rules...
+    'prx': (PhasedXPowGate, XPowGate, YPowGate),
+    'phased_rx': (PhasedXPowGate, XPowGate, YPowGate),
+    'cz': (CZPowGate,),
+    'move': (IQMMoveGate,),
+    'measurement': (MeasurementGate,),
+    'measure': (MeasurementGate,),
+    'barrier': tuple(),
+}
+
+
+def instruction_to_operation(instr: Instruction) -> Operation:
+    """Convert an IQM instruction to a Cirq Operation.
+
+    Args:
+        instr: the IQM instruction
+
+    Returns:
+        Operation: the converted operation
+
+    Raises:
+        OperationNotSupportedError When the circuit contains an unsupported operation.
+
+    """
+    if instr.name not in _IQM_CIRQ_OP_MAP:
+        raise OperationNotSupportedError(f'Operation {instr.name} not supported.')
+
+    gate_type = _IQM_CIRQ_OP_MAP[instr.name][0]
+    args_map = {'angle_t': 'exponent', 'phase_t': 'phase_exponent'}
+    args = {args_map[k]: v * 2 for k, v in instr.args.items() if k in args_map}
+    if 'key' in instr.args.keys():
+        args['key'] = instr.args['key']
+        args['num_qubits'] = len(instr.qubits)
+    qubits = [NamedQid(qubit, dimension=2) for qubit in instr.qubits]
+    return gate_type(**args)(*qubits)
 
 
 class OperationNotSupportedError(RuntimeError):

--- a/src/iqm/cirq_iqm/iqm_operation_mapping.py
+++ b/src/iqm/cirq_iqm/iqm_operation_mapping.py
@@ -16,6 +16,7 @@
 from cirq.ops import CZPowGate, MeasurementGate, Operation, PhasedXPowGate, XPowGate, YPowGate
 
 from iqm.iqm_client import Instruction
+from iqm.cirq_iqm.iqm_gates import IQMMoveGate
 
 
 class OperationNotSupportedError(RuntimeError):
@@ -76,6 +77,13 @@ def map_operation(operation: Operation) -> Instruction:
             )
         raise OperationNotSupportedError(
             f'CZPowGate exponent was {operation.gate.exponent}, but only 1 is natively supported.'
+        )
+    
+    if isinstance(operation.gate, IQMMoveGate):
+        return Instruction(
+            name='move',
+            qubits=tuple(qubits),
+            args={},
         )
 
     raise OperationNotSupportedError(f'{type(operation.gate)} not natively supported.')

--- a/src/iqm/cirq_iqm/iqm_operation_mapping.py
+++ b/src/iqm/cirq_iqm/iqm_operation_mapping.py
@@ -15,8 +15,8 @@
 """
 from cirq.ops import CZPowGate, MeasurementGate, Operation, PhasedXPowGate, XPowGate, YPowGate
 
-from iqm.iqm_client import Instruction
 from iqm.cirq_iqm.iqm_gates import IQMMoveGate
+from iqm.iqm_client import Instruction
 
 
 class OperationNotSupportedError(RuntimeError):
@@ -78,7 +78,7 @@ def map_operation(operation: Operation) -> Instruction:
         raise OperationNotSupportedError(
             f'CZPowGate exponent was {operation.gate.exponent}, but only 1 is natively supported.'
         )
-    
+
     if isinstance(operation.gate, IQMMoveGate):
         return Instruction(
             name='move',

--- a/src/iqm/cirq_iqm/iqm_operation_mapping.py
+++ b/src/iqm/cirq_iqm/iqm_operation_mapping.py
@@ -80,7 +80,7 @@ def map_operation(operation: Operation) -> Instruction:
 
     """
     phased_rx_name = 'prx'
-    qubits = [str(qubit) for qubit in operation.qubits]
+    qubits = [qubit.name if isinstance(qubit, NamedQid) else str(qubit) for qubit in operation.qubits]
     if isinstance(operation.gate, PhasedXPowGate):
         return Instruction(
             name=phased_rx_name,

--- a/src/iqm/cirq_iqm/iqm_sampler.py
+++ b/src/iqm/cirq_iqm/iqm_sampler.py
@@ -27,23 +27,9 @@ import warnings
 import cirq
 import numpy as np
 
-from iqm import iqm_client
 from iqm.cirq_iqm.devices.iqm_device import IQMDevice, IQMDeviceMetadata
-from iqm.cirq_iqm.iqm_operation_mapping import map_operation
+from iqm.cirq_iqm.serialize import serialize_circuit
 from iqm.iqm_client import HeraldingMode, IQMClient, JobAbortionError, RunRequest
-
-
-def serialize_circuit(circuit: cirq.Circuit) -> iqm_client.Circuit:
-    """Serializes a quantum circuit into the IQM data transfer format.
-
-    Args:
-        circuit: quantum circuit to serialize
-
-    Returns:
-        data transfer object representing the circuit
-    """
-    instructions = tuple(map(map_operation, circuit.all_operations()))
-    return iqm_client.Circuit(name='Serialized from Cirq', instructions=instructions)
 
 
 class IQMSampler(cirq.work.Sampler):

--- a/src/iqm/cirq_iqm/iqm_sampler.py
+++ b/src/iqm/cirq_iqm/iqm_sampler.py
@@ -29,7 +29,7 @@ import numpy as np
 
 from iqm.cirq_iqm.devices.iqm_device import IQMDevice, IQMDeviceMetadata
 from iqm.cirq_iqm.serialize import serialize_circuit
-from iqm.iqm_client import CircuitCompilationOptions, IQMClient, JobAbortionError, RunRequest
+from iqm.iqm_client import Circuit, CircuitCompilationOptions, IQMClient, JobAbortionError, RunRequest
 
 
 class IQMSampler(cirq.work.Sampler):

--- a/src/iqm/cirq_iqm/iqm_sampler.py
+++ b/src/iqm/cirq_iqm/iqm_sampler.py
@@ -29,7 +29,7 @@ import numpy as np
 
 from iqm.cirq_iqm.devices.iqm_device import IQMDevice, IQMDeviceMetadata
 from iqm.cirq_iqm.serialize import serialize_circuit
-from iqm.iqm_client import IQMClient, JobAbortionError, RunRequest, CircuitCompilationOptions
+from iqm.iqm_client import CircuitCompilationOptions, IQMClient, JobAbortionError, RunRequest
 
 
 class IQMSampler(cirq.work.Sampler):

--- a/src/iqm/cirq_iqm/serialize.py
+++ b/src/iqm/cirq_iqm/serialize.py
@@ -1,0 +1,51 @@
+# Copyright 2020–2022 Cirq on IQM developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Circuit sampler that executes quantum circuits on an IQM quantum computer.
+"""
+from cirq import Circuit
+
+from iqm import iqm_client
+from iqm.cirq_iqm.iqm_operation_mapping import instruction_to_operation, map_operation
+
+
+def serialize_circuit(circuit: Circuit) -> iqm_client.Circuit:
+    """Serializes a quantum circuit into the IQM data transfer format.
+
+    Args:
+        circuit: quantum circuit to serialize
+
+    Returns:
+        data transfer object representing the circuit
+    """
+    instructions = tuple(map(map_operation, circuit.all_operations()))
+    return iqm_client.Circuit(name='Serialized from Cirq', instructions=instructions)
+
+
+def deserialize_circuit(circuit: iqm_client.Circuit) -> Circuit:
+    """Deserializes a quantum circuit from the IQM data transfer format to a Cirq Circuit.
+
+    Args:
+        circuit: data transfer object representing the circuit
+
+    Returns:
+        quantum circuit
+    """
+    return Circuit(
+        map(
+            lambda instr: instruction_to_operation(instr),
+            circuit.instructions,
+        )
+    )

--- a/src/iqm/cirq_iqm/serialize.py
+++ b/src/iqm/cirq_iqm/serialize.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Circuit sampler that executes quantum circuits on an IQM quantum computer.
+Helper functions for serializing and deserializing quantum circuits between Cirq and IQM Circuit formats.
 """
 from cirq import Circuit
 

--- a/src/iqm/cirq_iqm/serialize.py
+++ b/src/iqm/cirq_iqm/serialize.py
@@ -45,7 +45,7 @@ def deserialize_circuit(circuit: iqm_client.Circuit) -> Circuit:
     """
     return Circuit(
         map(
-            lambda instr: instruction_to_operation(instr),
+            instruction_to_operation,
             circuit.instructions,
         )
     )

--- a/src/iqm/cirq_iqm/transpiler.py
+++ b/src/iqm/cirq_iqm/transpiler.py
@@ -1,0 +1,50 @@
+# Copyright 2020–2022 Cirq on IQM developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helper functions for IQM specific transpilation needs."""
+from __future__ import annotations
+
+from typing import Optional
+
+from cirq import Circuit
+
+from iqm.cirq_iqm.serialize import deserialize_circuit, serialize_circuit
+from iqm.iqm_client import ExistingMoveHandlingOptions, transpile_insert_moves
+
+
+def transpile_insert_moves_into_circuit(
+    cirq_circuit: Circuit,
+    device: "IQMDevice",
+    existing_moves: Optional[ExistingMoveHandlingOptions] = None,
+    qubit_mapping: Optional[dict[str, str]] = None,
+) -> Circuit:
+    """Transpile the circuit to insert MOVE gates where needed.
+
+    Args:
+        cirq_circuit (cirq.Circuit): Circuit to transpile.
+        device (IQMDevice): Device to transpile for.
+        existing_moves (ExistingMoveHandlingOptions) : How to handle existing MOVE gates.
+        qubit_mapping (dict[str, str]): Mapping from qubit names in the circuit to the device.
+
+    Returns:
+        cirq.Circuit: Transpiled circuit.
+    """
+    iqm_client_circuit = serialize_circuit(cirq_circuit)
+    new_iqm_client_circuit = transpile_insert_moves(
+        iqm_client_circuit,
+        device.metadata.to_architecture(),
+        existing_moves=existing_moves,
+        qubit_mapping=qubit_mapping,
+    )
+    new_cirq_circuit = deserialize_circuit(new_iqm_client_circuit)
+    return new_cirq_circuit

--- a/src/iqm/cirq_iqm/transpiler.py
+++ b/src/iqm/cirq_iqm/transpiler.py
@@ -31,13 +31,13 @@ def transpile_insert_moves_into_circuit(
     """Transpile the circuit to insert MOVE gates where needed.
 
     Args:
-        cirq_circuit (cirq.Circuit): Circuit to transpile.
-        device (IQMDevice): Device to transpile for.
-        existing_moves (ExistingMoveHandlingOptions) : How to handle existing MOVE gates.
-        qubit_mapping (dict[str, str]): Mapping from qubit names in the circuit to the device.
+        cirq_circuit: Circuit to transpile.
+        device: Device to transpile for.
+        existing_moves: How to handle existing MOVE gates, obtained from the IQM client library.
+        qubit_mapping: Mapping from qubit names in the circuit to the device.
 
     Returns:
-        cirq.Circuit: Transpiled circuit.
+        Transpiled circuit.
     """
     iqm_client_circuit = serialize_circuit(cirq_circuit)
     new_iqm_client_circuit = transpile_insert_moves(

--- a/src/iqm/cirq_iqm/transpiler.py
+++ b/src/iqm/cirq_iqm/transpiler.py
@@ -14,17 +14,20 @@
 """Helper functions for IQM specific transpilation needs."""
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from cirq import Circuit
 
 from iqm.cirq_iqm.serialize import deserialize_circuit, serialize_circuit
 from iqm.iqm_client import ExistingMoveHandlingOptions, transpile_insert_moves
 
+if TYPE_CHECKING:
+    from iqm.cirq_iqm.devices import IQMDevice
+
 
 def transpile_insert_moves_into_circuit(
     cirq_circuit: Circuit,
-    device: "IQMDevice",
+    device: IQMDevice,
     existing_moves: Optional[ExistingMoveHandlingOptions] = None,
     qubit_mapping: Optional[dict[str, str]] = None,
 ) -> Circuit:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from uuid import UUID
 
 import pytest
 
-from iqm.cirq_iqm import IQMDevice, IQMDeviceMetadata
+from iqm.cirq_iqm import Adonis, Apollo, IQMDevice, IQMDeviceMetadata
 from iqm.iqm_client import QuantumArchitectureSpecification
 
 existing_run = UUID('3c3fcda3-e860-46bf-92a4-bcc59fa76ce9')
@@ -87,11 +87,17 @@ def adonis_architecture_shuffled_names():
 
 @pytest.fixture()
 def device_without_resonator(adonis_architecture_shuffled_names):
-    """Returns device metadata object created based on architecture specification"""
+    """Returns device object created based on architecture specification"""
     return IQMDevice(IQMDeviceMetadata.from_architecture(adonis_architecture_shuffled_names))
 
 
 @pytest.fixture()
 def device_with_resonator(fake_spec_with_resonator):
-    """Returns device metadata object created based on architecture specification"""
+    """Returns device object created based on architecture specification"""
     return IQMDevice(IQMDeviceMetadata.from_architecture(fake_spec_with_resonator))
+
+
+@pytest.fixture()
+def devices(device_with_resonator, device_without_resonator):
+    """Returns a list of different device objects"""
+    return [device_without_resonator, device_with_resonator, Apollo(), Adonis()]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,11 @@ from uuid import UUID
 
 import pytest
 
+from iqm.iqm_client import QuantumArchitectureSpecification
+from iqm.iqm_client import IQMClient
+from iqm.cirq_iqm import IQMDevice, IQMDeviceMetadata
+from mockito import mock, when, unstub
+
 existing_run = UUID('3c3fcda3-e860-46bf-92a4-bcc59fa76ce9')
 missing_run = UUID('059e4186-50a3-4e6c-ba1f-37fe6afbdfc2')
 
@@ -27,3 +32,65 @@ missing_run = UUID('059e4186-50a3-4e6c-ba1f-37fe6afbdfc2')
 @pytest.fixture()
 def base_url():
     return 'https://example.com'
+
+@pytest.fixture()
+def fake_spec_with_resonator():
+    ndonis_architecture_specification = {
+        "name": "Ndonis",
+        "operations": {
+            "cz": [
+                ["QB1", "COMP_R"],
+                ["QB2", "COMP_R"],
+                ["QB3", "COMP_R"],
+                ["QB4", "COMP_R"],
+                ["QB5", "COMP_R"],
+                ["QB6", "COMP_R"],
+            ],
+            "prx": [["QB1"], ["QB2"], ["QB3"], ["QB4"], ["QB5"], ["QB6"]],
+            "move": [
+                ["QB1", "COMP_R"],
+                ["QB2", "COMP_R"],
+                ["QB3", "COMP_R"],
+                ["QB4", "COMP_R"],
+                ["QB5", "COMP_R"],
+                ["QB6", "COMP_R"],
+            ],
+            "barrier": [],
+            "measure": [["QB1"], ["QB2"], ["QB3"], ["QB4"], ["QB5"], ["QB6"]],
+        },
+        "qubits": ["COMP_R", "QB1", "QB2", "QB3", "QB4", "QB5", "QB6"],
+        "qubit_connectivity": [
+            ["QB1", "COMP_R"],
+            ["QB2", "COMP_R"],
+            ["QB3", "COMP_R"],
+            ["QB4", "COMP_R"],
+            ["QB5", "COMP_R"],
+            ["QB6", "COMP_R"],
+        ],
+    }
+    return QuantumArchitectureSpecification(**ndonis_architecture_specification)
+
+
+@pytest.fixture
+def adonis_architecture_shuffled_names():
+    return QuantumArchitectureSpecification(
+        name='Adonis',
+        operations={
+            'prx': [['QB2'], ['QB3'], ['QB1'], ['QB5'], ['QB4']],
+            'cz': [['QB1', 'QB3'], ['QB2', 'QB3'], ['QB4', 'QB3'], ['QB5', 'QB3']],
+            'measure': [['QB2'], ['QB3'], ['QB1'], ['QB5'], ['QB4']],
+            'barrier': [],
+        },
+        qubits=['QB2', 'QB3', 'QB1', 'QB5', 'QB4'],
+        qubit_connectivity=[['QB1', 'QB3'], ['QB2', 'QB3'], ['QB4', 'QB3'], ['QB5', 'QB3']],
+    )
+
+@pytest.fixture()
+def device_without_resonator(adonis_architecture_shuffled_names):
+    """Returns device metadata object created based on architecture specification"""
+    return IQMDevice(IQMDeviceMetadata.from_architecture(adonis_architecture_shuffled_names))
+
+@pytest.fixture()
+def device_with_resonator(fake_spec_with_resonator):
+    """Returns device metadata object created based on architecture specification"""
+    return IQMDevice(IQMDeviceMetadata.from_architecture(fake_spec_with_resonator))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,13 @@
 # Copyright 2020–2021 Cirq on IQM developers
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the License is distributed on an 'AS IS' BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
@@ -20,10 +20,8 @@ from uuid import UUID
 
 import pytest
 
-from iqm.iqm_client import QuantumArchitectureSpecification
-from iqm.iqm_client import IQMClient
 from iqm.cirq_iqm import IQMDevice, IQMDeviceMetadata
-from mockito import mock, when, unstub
+from iqm.iqm_client import QuantumArchitectureSpecification
 
 existing_run = UUID('3c3fcda3-e860-46bf-92a4-bcc59fa76ce9')
 missing_run = UUID('059e4186-50a3-4e6c-ba1f-37fe6afbdfc2')
@@ -33,39 +31,40 @@ missing_run = UUID('059e4186-50a3-4e6c-ba1f-37fe6afbdfc2')
 def base_url():
     return 'https://example.com'
 
+
 @pytest.fixture()
 def fake_spec_with_resonator():
     ndonis_architecture_specification = {
-        "name": "Ndonis",
-        "operations": {
-            "cz": [
-                ["QB1", "COMP_R"],
-                ["QB2", "COMP_R"],
-                ["QB3", "COMP_R"],
-                ["QB4", "COMP_R"],
-                ["QB5", "COMP_R"],
-                ["QB6", "COMP_R"],
+        'name': 'Ndonis',
+        'operations': {
+            'cz': [
+                ['QB1', 'COMP_R'],
+                ['QB2', 'COMP_R'],
+                ['QB3', 'COMP_R'],
+                ['QB4', 'COMP_R'],
+                ['QB5', 'COMP_R'],
+                ['QB6', 'COMP_R'],
             ],
-            "prx": [["QB1"], ["QB2"], ["QB3"], ["QB4"], ["QB5"], ["QB6"]],
-            "move": [
-                ["QB1", "COMP_R"],
-                ["QB2", "COMP_R"],
-                ["QB3", "COMP_R"],
-                ["QB4", "COMP_R"],
-                ["QB5", "COMP_R"],
-                ["QB6", "COMP_R"],
+            'prx': [['QB1'], ['QB2'], ['QB3'], ['QB4'], ['QB5'], ['QB6']],
+            'move': [
+                ['QB1', 'COMP_R'],
+                ['QB2', 'COMP_R'],
+                ['QB3', 'COMP_R'],
+                ['QB4', 'COMP_R'],
+                ['QB5', 'COMP_R'],
+                ['QB6', 'COMP_R'],
             ],
-            "barrier": [],
-            "measure": [["QB1"], ["QB2"], ["QB3"], ["QB4"], ["QB5"], ["QB6"]],
+            'barrier': [],
+            'measure': [['QB1'], ['QB2'], ['QB3'], ['QB4'], ['QB5'], ['QB6']],
         },
-        "qubits": ["COMP_R", "QB1", "QB2", "QB3", "QB4", "QB5", "QB6"],
-        "qubit_connectivity": [
-            ["QB1", "COMP_R"],
-            ["QB2", "COMP_R"],
-            ["QB3", "COMP_R"],
-            ["QB4", "COMP_R"],
-            ["QB5", "COMP_R"],
-            ["QB6", "COMP_R"],
+        'qubits': ['COMP_R', 'QB1', 'QB2', 'QB3', 'QB4', 'QB5', 'QB6'],
+        'qubit_connectivity': [
+            ['QB1', 'COMP_R'],
+            ['QB2', 'COMP_R'],
+            ['QB3', 'COMP_R'],
+            ['QB4', 'COMP_R'],
+            ['QB5', 'COMP_R'],
+            ['QB6', 'COMP_R'],
         ],
     }
     return QuantumArchitectureSpecification(**ndonis_architecture_specification)
@@ -85,10 +84,12 @@ def adonis_architecture_shuffled_names():
         qubit_connectivity=[['QB1', 'QB3'], ['QB2', 'QB3'], ['QB4', 'QB3'], ['QB5', 'QB3']],
     )
 
+
 @pytest.fixture()
 def device_without_resonator(adonis_architecture_shuffled_names):
     """Returns device metadata object created based on architecture specification"""
     return IQMDevice(IQMDeviceMetadata.from_architecture(adonis_architecture_shuffled_names))
+
 
 @pytest.fixture()
 def device_with_resonator(fake_spec_with_resonator):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from uuid import UUID
 
 import pytest
 
-from iqm.cirq_iqm import Adonis, Apollo, IQMDevice, IQMDeviceMetadata
+from iqm.cirq_iqm import IQMDevice, IQMDeviceMetadata
 from iqm.iqm_client import QuantumArchitectureSpecification
 
 existing_run = UUID('3c3fcda3-e860-46bf-92a4-bcc59fa76ce9')
@@ -95,9 +95,3 @@ def device_without_resonator(adonis_architecture_shuffled_names):
 def device_with_resonator(fake_spec_with_resonator):
     """Returns device object created based on architecture specification"""
     return IQMDevice(IQMDeviceMetadata.from_architecture(fake_spec_with_resonator))
-
-
-@pytest.fixture()
-def devices(device_with_resonator, device_without_resonator):
-    """Returns a list of different device objects"""
-    return [device_without_resonator, device_with_resonator, Apollo(), Adonis()]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,6 @@ def fake_spec_with_resonator():
                 ['QB3', 'COMP_R'],
                 ['QB4', 'COMP_R'],
                 ['QB5', 'COMP_R'],
-                ['QB6', 'COMP_R'],
             ],
             'barrier': [],
             'measure': [['QB1'], ['QB2'], ['QB3'], ['QB4'], ['QB5'], ['QB6']],
@@ -95,3 +94,53 @@ def device_without_resonator(adonis_architecture_shuffled_names):
 def device_with_resonator(fake_spec_with_resonator):
     """Returns device object created based on architecture specification"""
     return IQMDevice(IQMDeviceMetadata.from_architecture(fake_spec_with_resonator))
+
+
+@pytest.fixture
+def device_with_multiple_resonators():
+    """Some fictional 5 qubit device with multiple resonators."""
+    multiple_resonators_specification = {
+        'name': 'MultiResonators',
+        'operations': {
+            'cz': [
+                ['QB1', 'COMP_R0'],
+                ['QB2', 'COMP_R0'],
+                ['QB2', 'COMP_R1'],
+                ['QB3', 'COMP_R1'],
+                ['QB3', 'COMP_R2'],
+                ['QB4', 'COMP_R2'],
+                ['QB4', 'COMP_R3'],
+                ['QB5', 'COMP_R3'],
+                ['QB5', 'COMP_R4'],
+                ['QB1', 'COMP_R4'],
+                ['QB1', 'QB3'],
+            ],
+            'prx': [['QB2'], ['QB3'], ['QB1'], ['QB5'], ['QB4']],
+            'move': [
+                ['QB1', 'COMP_R0'],
+                ['QB2', 'COMP_R1'],
+                ['QB3', 'COMP_R2'],
+                ['QB4', 'COMP_R3'],
+                ['QB5', 'COMP_R4'],
+            ],
+            'barrier': [],
+            'measure': [['QB2'], ['QB3'], ['QB1'], ['QB5'], ['QB4']],
+        },
+        'qubits': ['COMP_R0', 'COMP_R1', 'COMP_R2', 'COMP_R3', 'COMP_R4', 'QB1', 'QB2', 'QB3', 'QB4', 'QB5'],
+        'qubit_connectivity': [
+            ['QB1', 'COMP_R0'],
+            ['QB2', 'COMP_R0'],
+            ['QB2', 'COMP_R1'],
+            ['QB3', 'COMP_R1'],
+            ['QB3', 'COMP_R2'],
+            ['QB4', 'COMP_R2'],
+            ['QB4', 'COMP_R3'],
+            ['QB5', 'COMP_R3'],
+            ['QB5', 'COMP_R4'],
+            ['QB1', 'COMP_R4'],
+            ['QB1', 'QB3'],
+        ],
+    }
+    return IQMDevice(
+        IQMDeviceMetadata.from_architecture(QuantumArchitectureSpecification(**multiple_resonators_specification))
+    )

--- a/tests/test_adonis.py
+++ b/tests/test_adonis.py
@@ -153,10 +153,10 @@ class TestOperationValidation:
 
         q0, q1 = adonis.qubits[:2]
 
-        with pytest.raises(ValueError, match='Unsupported qubit connectivity'):
+        with pytest.raises(ValueError, match='Unsupported operation between qubits'):
             adonis.validate_operation(gate(q0, q1))
 
-        with pytest.raises(ValueError, match='Unsupported qubit connectivity'):
+        with pytest.raises(ValueError, match='Unsupported operation between qubits'):
             adonis.validate_operation(gate(q1, q0))
 
 

--- a/tests/test_apollo.py
+++ b/tests/test_apollo.py
@@ -153,10 +153,10 @@ class TestOperationValidation:
 
         q0, _, q2 = apollo.qubits[:3]
 
-        with pytest.raises(ValueError, match='Unsupported qubit connectivity'):
+        with pytest.raises(ValueError, match='Unsupported operation between qubits'):
             apollo.validate_operation(gate(q0, q2))
 
-        with pytest.raises(ValueError, match='Unsupported qubit connectivity'):
+        with pytest.raises(ValueError, match='Unsupported operation between qubits'):
             apollo.validate_operation(gate(q2, q0))
 
 
@@ -395,10 +395,16 @@ class TestCircuitRouting:
             cirq.CZ(qubits[0], qubits[4]),
             cirq.CZ(qubits[0], qubits[5]),
         )
+        print('routing started')
+        print(circuit)
         routed_circuit, _, _ = apollo.route_circuit(circuit)
+        print('decomposing')
+        print(routed_circuit)
         valid_circuit = apollo.decompose_circuit(routed_circuit)
-
+        print('validating')
+        print(valid_circuit)
         apollo.validate_circuit(valid_circuit)
+        print('done')
 
     @pytest.mark.parametrize(
         'qid',

--- a/tests/test_iqm_device.py
+++ b/tests/test_iqm_device.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from iqm.cirq_iqm import Adonis, Apollo, Valkmusa
+from iqm.cirq_iqm import IQMDevice
 
+from cirq import NamedQid
+
+import pytest
 
 def test_equality_method():
     adonis_1 = Adonis()
@@ -27,3 +31,24 @@ def test_equality_method():
     assert valkmusa != adonis_1
     assert apollo_1 == apollo_2
     assert adonis_2 != adonis_3
+
+
+def test_device_without_resonator(device_without_resonator):
+    assert_qubit_indexing(device_without_resonator, set(zip(range(1,len(device_without_resonator.qubits)+1),device_without_resonator.qubits)))
+    assert len(device_without_resonator.resonators) == 0
+
+
+def test_device_with_resonator(device_with_resonator):
+    print(device_with_resonator.qubits)
+    # Tests for device with resonator should pass too.
+    assert_qubit_indexing(device_with_resonator, set(zip(range(1,len(device_with_resonator.qubits)+1),device_with_resonator.qubits)))
+    assert device_with_resonator.resonators[0] == NamedQid("COMP_R", device_with_resonator._metadata.RESONATOR_DIMENSION)
+
+def assert_qubit_indexing(backend:IQMDevice, correct_idx_name_associations):
+    for idx, name in correct_idx_name_associations:
+        print(idx, name, backend.get_qubit(idx), backend.get_qubit_index(name))
+    assert all(backend.get_qubit(idx) == name for idx, name in correct_idx_name_associations)
+    assert all(backend.get_qubit_index(name) == idx for idx, name in correct_idx_name_associations)
+    # Below assertions are done in Qiskit but do not make sense for Cirq.
+    #assert backend.index_to_qubit_name(7) is None
+    #assert backend.qubit_name_to_index('Alice') is None

--- a/tests/test_iqm_device.py
+++ b/tests/test_iqm_device.py
@@ -47,6 +47,7 @@ def test_device_with_resonator(device_with_resonator):
     assert_qubit_indexing(
         device_with_resonator, set(zip(range(1, len(device_with_resonator.qubits) + 1), device_with_resonator.qubits))
     )
+    assert len(device_with_resonator.resonators) == 1
     assert device_with_resonator.resonators[0] == NamedQid(
         "COMP_R", device_with_resonator._metadata.RESONATOR_DIMENSION
     )
@@ -152,6 +153,14 @@ def test_validate_moves(device_with_resonator):
     with pytest.raises(ValueError):
         device_with_resonator.validate_moves(circuit)
 
+    # Test odd valid MOVEs (incomplete sandwich)
+    circuit = Circuit(
+        IQMMoveGate()(device_with_resonator.qubits[0], device_with_resonator.resonators[0]),
+        IQMMoveGate()(device_with_resonator.qubits[0], device_with_resonator.resonators[0]),
+        IQMMoveGate()(device_with_resonator.qubits[0], device_with_resonator.resonators[0]),
+    )
+    with pytest.raises(ValueError):
+        device_with_resonator.validate_moves(circuit)
     # Test no moves
     circuit = Circuit()
     assert device_with_resonator.validate_moves(circuit) is None

--- a/tests/test_iqm_device.py
+++ b/tests/test_iqm_device.py
@@ -11,12 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from iqm.cirq_iqm import Adonis, Apollo, Valkmusa
-from iqm.cirq_iqm import IQMDevice
-
 from cirq import NamedQid
 
-import pytest
+from iqm.cirq_iqm import Adonis, Apollo, IQMDevice, Valkmusa
+
 
 def test_equality_method():
     adonis_1 = Adonis()
@@ -34,21 +32,29 @@ def test_equality_method():
 
 
 def test_device_without_resonator(device_without_resonator):
-    assert_qubit_indexing(device_without_resonator, set(zip(range(1,len(device_without_resonator.qubits)+1),device_without_resonator.qubits)))
+    assert_qubit_indexing(
+        device_without_resonator,
+        set(zip(range(1, len(device_without_resonator.qubits) + 1), device_without_resonator.qubits)),
+    )
     assert len(device_without_resonator.resonators) == 0
 
 
 def test_device_with_resonator(device_with_resonator):
     print(device_with_resonator.qubits)
     # Tests for device with resonator should pass too.
-    assert_qubit_indexing(device_with_resonator, set(zip(range(1,len(device_with_resonator.qubits)+1),device_with_resonator.qubits)))
-    assert device_with_resonator.resonators[0] == NamedQid("COMP_R", device_with_resonator._metadata.RESONATOR_DIMENSION)
+    assert_qubit_indexing(
+        device_with_resonator, set(zip(range(1, len(device_with_resonator.qubits) + 1), device_with_resonator.qubits))
+    )
+    assert device_with_resonator.resonators[0] == NamedQid(
+        "COMP_R", device_with_resonator._metadata.RESONATOR_DIMENSION
+    )
 
-def assert_qubit_indexing(backend:IQMDevice, correct_idx_name_associations):
+
+def assert_qubit_indexing(backend: IQMDevice, correct_idx_name_associations):
     for idx, name in correct_idx_name_associations:
         print(idx, name, backend.get_qubit(idx), backend.get_qubit_index(name))
     assert all(backend.get_qubit(idx) == name for idx, name in correct_idx_name_associations)
     assert all(backend.get_qubit_index(name) == idx for idx, name in correct_idx_name_associations)
     # Below assertions are done in Qiskit but do not make sense for Cirq.
-    #assert backend.index_to_qubit_name(7) is None
-    #assert backend.qubit_name_to_index('Alice') is None
+    # assert backend.index_to_qubit_name(7) is None
+    # assert backend.qubit_name_to_index('Alice') is None

--- a/tests/test_iqm_device.py
+++ b/tests/test_iqm_device.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from cirq import NamedQid
+from typing import List
+
+from cirq import HardCodedInitialMapper, NamedQid
+from cirq.testing import assert_circuits_have_same_unitary_given_final_permutation, random_circuit
 
 from iqm.cirq_iqm import Adonis, Apollo, IQMDevice, Valkmusa
 
@@ -51,10 +54,35 @@ def test_device_with_resonator(device_with_resonator):
 
 
 def assert_qubit_indexing(backend: IQMDevice, correct_idx_name_associations):
-    for idx, name in correct_idx_name_associations:
-        print(idx, name, backend.get_qubit(idx), backend.get_qubit_index(name))
     assert all(backend.get_qubit(idx) == name for idx, name in correct_idx_name_associations)
     assert all(backend.get_qubit_index(name) == idx for idx, name in correct_idx_name_associations)
     # Below assertions are done in Qiskit but do not make sense for Cirq.
     # assert backend.index_to_qubit_name(7) is None
     # assert backend.qubit_name_to_index('Alice') is None
+
+
+def test_transpilation(devices: List[IQMDevice]):
+    for device in devices:
+        if len(device.resonators) == 0: #TODO Remove to test resonator support.
+            print(device)
+            circuit = random_circuit(device.qubits[:5], 5, 1, random_state=1337)
+            print(circuit)
+            print("decomposing")
+            decomposed_circuit = device.decompose_circuit(circuit)
+            naive_map = {q: q for q in device.qubits}
+            print("routing")
+            routed_circuit, initial_map, final_map = device.route_circuit(
+                decomposed_circuit, initial_mapper=HardCodedInitialMapper(naive_map)
+            )
+            print("deocmposing")
+            decomposed_routed_circuit = device.decompose_circuit(routed_circuit)
+            assert initial_map == naive_map
+            print("validating")
+            device.validate_circuit(decomposed_routed_circuit)
+            print("checking equivalence")
+            qubit_map = {q1: q2 for q1, q2 in final_map.items() if q1 in decomposed_routed_circuit.all_qubits()}
+            print(decomposed_routed_circuit)
+            print(final_map)
+            assert_circuits_have_same_unitary_given_final_permutation(
+                decomposed_routed_circuit, circuit, qubit_map=qubit_map
+            )

--- a/tests/test_iqm_device.py
+++ b/tests/test_iqm_device.py
@@ -108,7 +108,7 @@ def test_qubit_connectivity(device: IQMDevice, request):
             edge in device.supported_operations[ops.CZPowGate]
             or tuple(reversed(edge)) in device.supported_operations[ops.CZPowGate]
         ):
-            assert device.check_qubit_connectivity(gate) is None
+            device.check_qubit_connectivity(gate)  # This should not raise an error
         else:
             with pytest.raises(ValueError):
                 device.check_qubit_connectivity(gate)

--- a/tests/test_iqm_device.py
+++ b/tests/test_iqm_device.py
@@ -63,7 +63,7 @@ def assert_qubit_indexing(backend: IQMDevice, correct_idx_name_associations):
 
 def test_transpilation(devices: List[IQMDevice]):
     for device in devices:
-        if len(device.resonators) == 0: #TODO Remove to test resonator support.
+        if len(device.resonators) == 0:  # TODO Remove to test resonator support.
             print(device)
             circuit = random_circuit(device.qubits[:5], 5, 1, random_state=1337)
             print(circuit)

--- a/tests/test_iqm_operation_mapping.py
+++ b/tests/test_iqm_operation_mapping.py
@@ -14,9 +14,11 @@
 import cirq
 from cirq import CZPowGate, GateOperation, MeasurementGate, PhasedXPowGate, XPowGate, YPowGate, ZPowGate
 import pytest
+from mockito import mock
 
-from iqm.cirq_iqm.iqm_operation_mapping import OperationNotSupportedError, map_operation
+from iqm.cirq_iqm.iqm_operation_mapping import OperationNotSupportedError, map_operation, instruction_to_operation
 from iqm.iqm_client import Instruction
+from iqm.cirq_iqm.iqm_gates import IQMMoveGate
 
 
 @pytest.fixture()
@@ -81,3 +83,34 @@ def test_raises_error_for_non_trivial_invert_mask(qubit_1, qubit_2):
     operation = GateOperation(MeasurementGate(2, 'measurement key', invert_mask=(True, False)), [qubit_1, qubit_2])
     with pytest.raises(OperationNotSupportedError):
         map_operation(operation)
+
+
+def test_instruction_to_operation():
+    instruction = Instruction(name='prx', qubits=('QB1',), args={'angle_t': 0.5, 'phase_t': 0.25})
+    operation = instruction_to_operation(instruction)
+    assert isinstance(operation.gate, PhasedXPowGate)
+    assert operation.qubits == (cirq.NamedQubit('QB1'),)
+    assert operation.gate.exponent == 1.0
+    assert operation.gate.phase_exponent == 0.5
+
+    instruction = Instruction(name='cz', qubits=('QB1', 'QB2'), args={})
+    operation = instruction_to_operation(instruction)
+    assert isinstance(operation.gate, CZPowGate)
+    assert operation.qubits == (cirq.NamedQubit('QB1'), cirq.NamedQubit('QB2'))
+    assert operation.gate.exponent == 1.0
+    assert operation.gate.global_shift == 0.0
+
+    instruction = Instruction(name='measurement', qubits=('QB1',), args={'key': 'test key'})
+    operation = instruction_to_operation(instruction)
+    assert isinstance(operation.gate, MeasurementGate)
+    assert operation.qubits == (cirq.NamedQubit('QB1'),)
+    assert operation.gate.key == 'test key'
+
+    instruction = mock({'name': 'unsupported', 'qubits': ('QB1',), 'args': {}}, spec=Instruction)
+    with pytest.raises(OperationNotSupportedError):
+        operation = instruction_to_operation(instruction)
+
+    instruction = Instruction(name='move', qubits=('QB1', 'COMP_R'), args={})
+    operation = instruction_to_operation(instruction)
+    assert isinstance(operation.gate, IQMMoveGate)
+    assert operation.qubits == (cirq.NamedQubit('QB1'), cirq.NamedQid('COMP_R', dimension=2))

--- a/tests/test_iqm_operation_mapping.py
+++ b/tests/test_iqm_operation_mapping.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 import cirq
 from cirq import CZPowGate, GateOperation, MeasurementGate, PhasedXPowGate, XPowGate, YPowGate, ZPowGate
-import pytest
 from mockito import mock
+import pytest
 
-from iqm.cirq_iqm.iqm_operation_mapping import OperationNotSupportedError, map_operation, instruction_to_operation
-from iqm.iqm_client import Instruction
 from iqm.cirq_iqm.iqm_gates import IQMMoveGate
+from iqm.cirq_iqm.iqm_operation_mapping import OperationNotSupportedError, instruction_to_operation, map_operation
+from iqm.iqm_client import Instruction
 
 
 @pytest.fixture()

--- a/tests/test_iqm_sampler.py
+++ b/tests/test_iqm_sampler.py
@@ -334,7 +334,7 @@ def test_run_ndonis(device_with_resonator, base_url, iqm_metadata, submit_circui
     circuit.append(cirq.CZ(resonator, qubit_2))
     circuit.append(IQMMoveGate().on(qubit_1, resonator))
     circuit.append(device_with_resonator.decompose_operation(cirq.H(qubit_2)))
-    circuit.append(cirq.measure(qubit_1, qubit_2, key='result'))
+    circuit.append(cirq.MeasurementGate(2, key='result').on(qubit_1, qubit_2))
 
     sampler._client = client
     result = sampler.run(circuit, repetitions=repetitions)

--- a/tests/test_iqm_sampler.py
+++ b/tests/test_iqm_sampler.py
@@ -27,10 +27,10 @@ from iqm.cirq_iqm.iqm_gates import IQMMoveGate
 from iqm.cirq_iqm.iqm_sampler import IQMResult, IQMSampler, ResultMetadata
 from iqm.iqm_client import (
     Circuit,
+    CircuitCompilationOptions,
     HeraldingMode,
     Instruction,
     IQMClient,
-    CircuitCompilationOptions,
     JobAbortionError,
     Metadata,
     RunRequest,
@@ -195,7 +195,7 @@ def test_run_sweep_has_heralding_mode_none_by_default(
     sampler = IQMSampler(base_url, Adonis())
     run_result = RunResult(status=Status.READY, measurements=[{'some stuff': [[0], [1]]}], metadata=iqm_metadata)
     kwargs = submit_circuits_default_kwargs
-    assert sampler._compiler_options.heralding_mode is None
+    assert sampler._compiler_options.heralding_mode is HeraldingMode.NONE
     when(client).submit_circuits(ANY, options=ANY, **kwargs).thenReturn(job_id)
     when(client).wait_for_results(job_id).thenReturn(run_result)
 

--- a/tests/test_iqm_sampler.py
+++ b/tests/test_iqm_sampler.py
@@ -22,8 +22,8 @@ import pytest
 import sympy  # type: ignore
 
 from iqm.cirq_iqm import Adonis
-from iqm.cirq_iqm.iqm_sampler import IQMResult, IQMSampler, ResultMetadata
 from iqm.cirq_iqm.iqm_gates import IQMMoveGate
+from iqm.cirq_iqm.iqm_sampler import IQMResult, IQMSampler, ResultMetadata
 from iqm.iqm_client import (
     Circuit,
     HeraldingMode,
@@ -312,6 +312,7 @@ def test_run(adonis_sampler, iqm_metadata, submit_circuits_default_kwargs, job_i
     assert isinstance(result.metadata, ResultMetadata)
     np.testing.assert_array_equal(result.measurements['some stuff'], np.array([[0]]))
 
+
 @pytest.mark.usefixtures('unstub')
 def test_run_ndonis(device_with_resonator, base_url, iqm_metadata, submit_circuits_default_kwargs, job_id):
     sampler = IQMSampler(base_url, device=device_with_resonator)
@@ -341,6 +342,7 @@ def test_run_ndonis(device_with_resonator, base_url, iqm_metadata, submit_circui
     assert isinstance(result, IQMResult)
     assert isinstance(result.metadata, ResultMetadata)
     np.testing.assert_array_equal(result.measurements['some stuff'], np.array([[0]]))
+
 
 @pytest.mark.usefixtures('unstub')
 def test_run_iqm_batch(adonis_sampler, iqm_metadata, submit_circuits_default_kwargs, job_id):


### PR DESCRIPTION
Added naive MOVE gate insertion support for use of Deneb with Cirq. 
The tests can only pass after https://github.com/iqm-finland/iqm-client/pull/124 has been merged.