### PR TITLE
Remove unnecessary build files when publishing documentation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,6 +69,8 @@ jobs:
         run: |
           tox -e docs
           touch build/sphinx/html/.nojekyll  # allow underscores in URL path
+          # remove unnecessary build files
+          sudo rm -rf build/sphinx/html/.doctrees
       - name: Publish to gh-pages
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 14.5
+============
+
+* Remove unnecessary build files when publishing documentation. `#138 <https://github.com/iqm-finland/iqm-client/pull/138>`_
+
 Version 14.4
 ============
 


### PR DESCRIPTION
Does the same thing as https://github.com/iqm-finland/iqm-client/pull/133.

Here I didn't add documentation about the alternative `git clone` options, because the repository size is not as big as iqm-client (~50MB vs ~500MB), so it's still pretty fast to clone normally.