### PR TITLE
Use dynamic quantum architecture (DQA) for circuit decomposition/routing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,8 @@ jobs:
         uses: actions/download-artifact@v4
       - name: Publish distribution packages to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: false
 
   publish_docs:
     runs-on: ubuntu-latest

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Contributors
 * Olli Tyrkkö <otyrkko@meetiqm.com>
 * Rakhim Davletkaliyev <rakhim.davletkaliyev@meetiqm.com>
 * Jake Muff <jake.muff@vtt.fi>
+* Janne Kotilahti <janne@meetiqm.com>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Version 15.0
 
 * Use dynamic quantum architecture for circuit decomposition and routing. `#139 <https://github.com/iqm-finland/cirq-on-iqm/pull/139>`_
 * Require iqm-client >= 20.0. `#139 <https://github.com/iqm-finland/cirq-on-iqm/pull/139>`_
+* Disable attestations on ``gh-action-pypi-publish`` to fix failing PyPI publishing. `#139 <https://github.com/iqm-finland/cirq-on-iqm/pull/139>`_
 
 Version 14.6
 ============

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 15.0
+============
+
+* Use dynamic quantum architecture for circuit decomposition and routing. `#139 <https://github.com/iqm-finland/cirq-on-iqm/pull/139>`_
+* Require iqm-client >= 20.0. `#139 <https://github.com/iqm-finland/cirq-on-iqm/pull/139>`_
+
 Version 14.6
 ============
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -267,15 +267,20 @@ Cirq contains various simulators which you can use to simulate the circuits cons
 In this subsection we demonstrate how to run them on an IQM quantum computer.
 
 Cirq on IQM provides :class:`.IQMSampler`, a subclass of :class:`cirq.work.Sampler`, which is used
-to execute quantum circuits. Once you have access to an IQM server you can create an :class:`.IQMSampler`
-instance and use its :meth:`~.IQMSampler.run` method to send a circuit for execution and retrieve the results:
+to execute quantum circuits and decompose/route them for the architecture of the quantum computer.
+Once you have access to an IQM server you can create an :class:`.IQMSampler` instance and use its
+:meth:`~.IQMSampler.run` method to send a circuit for execution and retrieve the results:
 
 .. code-block:: python
 
    from iqm.cirq_iqm.iqm_sampler import IQMSampler
 
+   # circuit = ...
+
    sampler = IQMSampler(iqm_server_url)
-   result = sampler.run(routed_circuit_1, repetitions=10)
+   decomposed_circuit = sampler.device.decompose_circuit(circuit)
+   routed_circuit, _, _ = sampler.device.route_circuit(decomposed_circuit)
+   result = sampler.run(routed_circuit, repetitions=10)
    print(result.measurements['m'])
 
 
@@ -337,8 +342,10 @@ For example if you would like to use a particular calibration set, you can provi
 
 
 The sampler will by default use an :class:`.IQMDevice` created based on architecture data obtained
-from the server, which is then available in the :attr:`.IQMSampler.device` property. Alternatively,
-the device can be specified directly with the :attr:`device` argument.
+from the server, which is then available in the :attr:`.IQMSampler.device` property. The architecture
+data depends on the calibration set used by the sampler, so one should usually use different sampler
+instances for different calibration sets. Alternatively, the device can be specified directly with
+the :attr:`device` argument, but this is not recommended when running on a real quantum computer.
 
 When executing a circuit that uses something other than the device qubits, you need to route it first,
 as explained in the :ref:`routing` section above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "numpy",
     "cirq-core[contrib] ~= 1.2",
     "ply",  # Required by cirq.contrib.qasm_import
-    "iqm-client >= 18.0, < 19.0"
+    "iqm-client >= 20.0, < 21.0"
 ]
 
 [project.urls]

--- a/src/iqm/cirq_iqm/devices/iqm_device.py
+++ b/src/iqm/cirq_iqm/devices/iqm_device.py
@@ -206,6 +206,9 @@ class IQMDevice(devices.Device):
         routing. The transformer :class:`cirq.RouterCQC` is used for routing.
         Note that only gates of one or two qubits, and measurement operations of arbitrary size are supported.
 
+        Adds the attribute ``iqm_calibration_set_id`` to the routed circuit, with value taken from
+        ``self.metadata.architecture.calibration_set_id`` if available, otherwise None.
+
         Args:
             circuit: Circuit to route.
             initial_mapper: Initial mapping from ``circuit`` qubits to device qubits, to serve as
@@ -258,10 +261,17 @@ class IQMDevice(devices.Device):
             # Insert IQMMoveGates into the circuit.
             routed_circuit = transpile_insert_moves_into_circuit(routed_circuit, self)
 
+        routed_circuit.iqm_calibration_set_id = (  # type: ignore
+            self._metadata.architecture.calibration_set_id if self._metadata.architecture is not None else None
+        )
+
         return routed_circuit, initial_mapping, final_mapping
 
     def decompose_circuit(self, circuit: cirq.Circuit) -> cirq.Circuit:
         """Decomposes the given circuit to the native gate set of the device.
+
+        Adds the attribute ``iqm_calibration_set_id`` to the decomposed circuit, with value taken from
+        ``self.metadata.architecture.calibration_set_id`` if available, otherwise None.
 
         Args:
             circuit: circuit to decompose
@@ -274,7 +284,11 @@ class IQMDevice(devices.Device):
             self.decompose_operation,
             preserve_moments=False,
         )
-        return cirq.Circuit(moments)
+        decomposed_circuit = cirq.Circuit(moments)
+        decomposed_circuit.iqm_calibration_set_id = (  # type: ignore
+            self._metadata.architecture.calibration_set_id if self._metadata.architecture is not None else None
+        )
+        return decomposed_circuit
 
     def validate_circuit(self, circuit: cirq.AbstractCircuit) -> None:
         super().validate_circuit(circuit)

--- a/src/iqm/cirq_iqm/devices/iqm_device.py
+++ b/src/iqm/cirq_iqm/devices/iqm_device.py
@@ -21,7 +21,6 @@ to use with the architecture.
 from __future__ import annotations
 
 import collections.abc as ca
-from itertools import zip_longest
 from math import pi as PI
 from typing import Optional, Sequence, cast
 

--- a/src/iqm/cirq_iqm/devices/iqm_device_metadata.py
+++ b/src/iqm/cirq_iqm/devices/iqm_device_metadata.py
@@ -22,7 +22,7 @@ from cirq import Gate, NamedQid, devices, ops
 from cirq.contrib.routing.router import nx
 
 from iqm.cirq_iqm.iqm_operation_mapping import _IQM_CIRQ_OP_MAP
-from iqm.iqm_client import QuantumArchitectureSpecification
+from iqm.iqm_client import DynamicQuantumArchitecture
 
 
 @cirq.value.value_equality
@@ -35,6 +35,7 @@ class IQMDeviceMetadata(devices.DeviceMetadata):
         operations: Supported quantum operations of the device, mapping op types to their possible loci.
         gateset: Native gateset of the device. If None, a default IQM device gateset will be used.
         resonators: computational resonators of the device
+        architecture: architecture from which values of the other arguments were obtained
     """
 
     QUBIT_NAME_PREFIX: str = 'QB'
@@ -51,6 +52,7 @@ class IQMDeviceMetadata(devices.DeviceMetadata):
         operations: Optional[dict[type[cirq.Gate], list[tuple[cirq.NamedQid, ...]]]] = None,
         gateset: Optional[cirq.Gateset] = None,
         resonators: Iterable[NamedQid] = (),
+        architecture: Optional[DynamicQuantumArchitecture] = None,
     ):
         """Construct an IQMDeviceMetadata object."""
         nx_graph = nx.Graph()
@@ -79,6 +81,8 @@ class IQMDeviceMetadata(devices.DeviceMetadata):
             raise ValueError('Operations must be provided if a gateset is provided, it cannot be reconstructed.')
         self.operations = operations
 
+        self.architecture = architecture
+
     @property
     def resonator_set(self) -> FrozenSet[NamedQid]:
         """Returns the set of resonators on the device.
@@ -89,55 +93,46 @@ class IQMDeviceMetadata(devices.DeviceMetadata):
         return self._resonator_set
 
     @classmethod
-    def from_architecture(cls, architecture: QuantumArchitectureSpecification) -> IQMDeviceMetadata:
-        """Returns device metadata object created based on architecture specification"""
-        qubits = tuple(NamedQid(qb, dimension=2) for qb in architecture.qubits if qb.startswith(cls.QUBIT_NAME_PREFIX))
+    def from_architecture(cls, architecture: DynamicQuantumArchitecture) -> IQMDeviceMetadata:
+        """Returns device metadata object created based on dynamic quantum architecture"""
+        qubits = tuple(NamedQid(qb, dimension=2) for qb in architecture.qubits)
         resonators = tuple(
-            NamedQid(qb, dimension=cls.RESONATOR_DIMENSION)
-            for qb in architecture.qubits
-            if not qb.startswith(cls.QUBIT_NAME_PREFIX)
+            NamedQid(cr, dimension=cls.RESONATOR_DIMENSION) for cr in architecture.computational_resonators
         )
         connectivity = tuple(
             tuple(
                 (
-                    NamedQid(qb, dimension=2)
-                    if qb.startswith(cls.QUBIT_NAME_PREFIX)
-                    else NamedQid(qb, dimension=cls.RESONATOR_DIMENSION)
+                    NamedQid(component, dimension=2)
+                    if component in qubits
+                    else NamedQid(component, dimension=cls.RESONATOR_DIMENSION)
                 )
-                for qb in edge
+                for component in locus
             )
-            for edge in architecture.qubit_connectivity
+            for gate_name, gate_info in architecture.gates.items()
+            for locus in gate_info.loci
+            if len(locus) > 1
         )
         operations: dict[type[cirq.Gate], list[tuple[NamedQid, ...]]] = {
             cirq_op: [
                 tuple(
                     (
-                        NamedQid(qb, dimension=2)
-                        if qb.startswith(cls.QUBIT_NAME_PREFIX)
-                        else NamedQid(qb, dimension=cls.RESONATOR_DIMENSION)
+                        NamedQid(component, dimension=2)
+                        if component in qubits
+                        else NamedQid(component, dimension=cls.RESONATOR_DIMENSION)
                     )
-                    for qb in args
+                    for component in locus
                 )
-                for args in qubits
+                for locus in gate_info.loci
             ]
-            for iqm_op, qubits in architecture.operations.items()
-            for cirq_op in _IQM_CIRQ_OP_MAP[iqm_op]
+            for gate_name, gate_info in architecture.gates.items()
+            for cirq_op in _IQM_CIRQ_OP_MAP[gate_name]
         }
-        return cls(qubits, connectivity, operations=operations, resonators=resonators)
-
-    def to_architecture(self) -> QuantumArchitectureSpecification:
-        """Returns the architecture specification object created based on device metadata."""
-        qubits = tuple(qb.name for qb in self._qubit_set)
-        resonators = tuple(qb.name for qb in self.resonator_set)
-        connectivity = tuple(tuple(qb.name for qb in edge) for edge in self.nx_graph.edges())
-        operations: dict[str, list[tuple[str, ...]]] = {
-            iqm_op: [tuple(qb.name for qb in args) for args in qubits]
-            for cirq_op, qubits in self.operations.items()
-            for iqm_op, cirq_ops in _IQM_CIRQ_OP_MAP.items()
-            if cirq_op in cirq_ops
-        }
-        return QuantumArchitectureSpecification(
-            name='From Cirq object', qubits=resonators + qubits, qubit_connectivity=connectivity, operations=operations
+        return cls(
+            qubits,
+            connectivity,
+            operations=operations,
+            resonators=resonators,
+            architecture=architecture,
         )
 
     @classmethod

--- a/src/iqm/cirq_iqm/devices/iqm_device_metadata.py
+++ b/src/iqm/cirq_iqm/devices/iqm_device_metadata.py
@@ -57,10 +57,9 @@ class IQMDeviceMetadata(devices.DeviceMetadata):
         """Construct an IQMDeviceMetadata object."""
         nx_graph = nx.Graph()
         for edge in connectivity:
-            edge_qubits = list(edge)
-            if len(edge_qubits) != 2:
+            if len(edge) != 2:
                 raise ValueError('Connectivity must be an iterable of 2-tuples.')
-            nx_graph.add_edge(edge_qubits[0], edge_qubits[1])
+            nx_graph.add_edge(edge[0], edge[1])
         super().__init__(qubits, nx_graph)
         self._qubit_set: FrozenSet[NamedQid] = frozenset(qubits)
         self._resonator_set: FrozenSet[NamedQid] = frozenset(resonators)

--- a/src/iqm/cirq_iqm/iqm_operation_mapping.py
+++ b/src/iqm/cirq_iqm/iqm_operation_mapping.py
@@ -24,10 +24,8 @@ _IQM_CIRQ_OP_MAP: dict[str, tuple[type[Gate], ...]] = {
     # XPow and YPow kept for convenience, Cirq does not know how to decompose them into PhasedX
     # so we would have to add those rules...
     'prx': (PhasedXPowGate, XPowGate, YPowGate),
-    'phased_rx': (PhasedXPowGate, XPowGate, YPowGate),
     'cz': (CZPowGate,),
     'move': (IQMMoveGate,),
-    'measurement': (MeasurementGate,),
     'measure': (MeasurementGate,),
     'barrier': tuple(),
 }
@@ -104,7 +102,7 @@ def map_operation(operation: Operation) -> Instruction:
             raise OperationNotSupportedError('Invert mask not supported')
 
         return Instruction(
-            name='measurement',
+            name='measure',
             qubits=tuple(qubits),
             args={'key': operation.gate.key},
         )

--- a/src/iqm/cirq_iqm/iqm_sampler.py
+++ b/src/iqm/cirq_iqm/iqm_sampler.py
@@ -66,27 +66,22 @@ class IQMSampler(cirq.work.Sampler):
         **user_auth_args,  # contains keyword args auth_server_url, username and password
     ):
         self._client = IQMClient(url, client_signature=f'cirq-iqm {version("cirq-iqm")}', **user_auth_args)
-        self._use_default_calibration_set = False
+        dqa = self._client.get_dynamic_quantum_architecture(calibration_set_id)
+        server_device_metadata = IQMDeviceMetadata.from_architecture(dqa)
+        self._use_default_calibration_set = calibration_set_id is None
+        self._calibration_set_id = dqa.calibration_set_id
         if device is None:
-            device_metadata = IQMDeviceMetadata.from_architecture(
-                self._client.get_dynamic_quantum_architecture(calibration_set_id)
-            )
-            self._device = IQMDevice(device_metadata)
-            if calibration_set_id is None:
-                self._use_default_calibration_set = True
+            self._device = IQMDevice(server_device_metadata)
         else:
-            if calibration_set_id is not None:
-                # validate device compatibility with the given calibration set
-                device_metadata = IQMDeviceMetadata.from_architecture(
-                    self._client.get_dynamic_quantum_architecture(calibration_set_id)
-                )
-                if device.metadata != device_metadata:  # checks equality using device.metadata._value_equality_values_
-                    raise ValueError(f"The given 'device' is not compatible with calibration set {calibration_set_id}.")
+            # validate device compatibility with the calibration set
+            if device.metadata != server_device_metadata:
+                if self._use_default_calibration_set:
+                    raise ValueError(
+                        "The given 'device' is not compatible with the server default calibration set "
+                        f'{self._calibration_set_id}.'
+                    )
+                raise ValueError(f"The given 'device' is not compatible with calibration set {calibration_set_id}.")
             self._device = device
-        if self._device.metadata.architecture is None:
-            self._calibration_set_id = calibration_set_id
-        else:
-            self._calibration_set_id = self._device.metadata.architecture.calibration_set_id
         self._run_sweep_timeout = run_sweep_timeout
         self._compiler_options = compiler_options if compiler_options is not None else CircuitCompilationOptions()
 
@@ -164,28 +159,27 @@ class IQMSampler(cirq.work.Sampler):
         if not self._client:
             raise RuntimeError('Cannot submit circuits since session to IQM client has been closed.')
 
-        if self._calibration_set_id is not None:
-            different_calset_ids = set()
-            for circuit in programs:
-                if hasattr(circuit, 'iqm_calibration_set_id'):
-                    if circuit.iqm_calibration_set_id != self._calibration_set_id:
-                        different_calset_ids.add(circuit.iqm_calibration_set_id)
-                else:
-                    different_calset_ids.add(None)
-            if different_calset_ids:
+        different_calset_ids = set()
+        for circuit in programs:
+            if hasattr(circuit, 'iqm_calibration_set_id'):
+                if circuit.iqm_calibration_set_id != self._calibration_set_id:
+                    different_calset_ids.add(circuit.iqm_calibration_set_id)
+            else:
+                different_calset_ids.add(None)
+        if different_calset_ids:
+            warnings.warn(
+                f'Circuits have been decomposed/routed using calibration set(s) {different_calset_ids}, '
+                f'different than the current calibration set {self._calibration_set_id} of this sampler. '
+                f'Decompose/route the circuits using this sampler to ensure successful execution.'
+            )
+        if self._use_default_calibration_set:
+            default_calset_id = self._client.get_dynamic_quantum_architecture(None).calibration_set_id
+            if self._calibration_set_id != default_calset_id:
                 warnings.warn(
-                    f'Circuits have been decomposed/routed using calibration set(s) {different_calset_ids}, '
-                    f'different than the current calibration set {self._calibration_set_id} of this sampler. '
-                    f'Decompose/route the circuits using this sampler to ensure successful execution.'
+                    f'Server default calibration set has changed from {self._calibration_set_id} '
+                    f'to {default_calset_id}. Use a new IQMSampler to decompose/route the circuits using '
+                    'the new calibration set to ensure successful execution.'
                 )
-            if self._use_default_calibration_set:
-                default_calset_id = self._client.get_dynamic_quantum_architecture(None).calibration_set_id
-                if self._calibration_set_id != default_calset_id:
-                    warnings.warn(
-                        f'Server default calibration set has changed from {self._calibration_set_id} '
-                        f'to {default_calset_id}. Use a new IQMSampler to decompose/route the circuits using '
-                        'the new calibration set to ensure successful execution.'
-                    )
 
         return self._client.create_run_request(
             serialized_circuits,

--- a/src/iqm/cirq_iqm/iqm_sampler.py
+++ b/src/iqm/cirq_iqm/iqm_sampler.py
@@ -75,6 +75,13 @@ class IQMSampler(cirq.work.Sampler):
             if calibration_set_id is None:
                 self._use_default_calibration_set = True
         else:
+            if calibration_set_id is not None:
+                # validate device compatibility with the given calibration set
+                device_metadata = IQMDeviceMetadata.from_architecture(
+                    self._client.get_dynamic_quantum_architecture(calibration_set_id)
+                )
+                if device.metadata != device_metadata:  # checks equality using device.metadata._value_equality_values_
+                    raise ValueError(f"The given 'device' is not compatible with calibration set {calibration_set_id}.")
             self._device = device
         if self._device.metadata.architecture is None:
             self._calibration_set_id = calibration_set_id

--- a/src/iqm/cirq_iqm/iqm_sampler.py
+++ b/src/iqm/cirq_iqm/iqm_sampler.py
@@ -58,8 +58,8 @@ class IQMSampler(cirq.work.Sampler):
     def __init__(
         self,
         url: str,
-        device: Optional[IQMDevice] = None,
         *,
+        device: Optional[IQMDevice] = None,
         calibration_set_id: Optional[UUID] = None,
         run_sweep_timeout: Optional[int] = None,
         compiler_options: Optional[CircuitCompilationOptions] = None,

--- a/src/iqm/cirq_iqm/iqm_sampler.py
+++ b/src/iqm/cirq_iqm/iqm_sampler.py
@@ -177,7 +177,7 @@ class IQMSampler(cirq.work.Sampler):
                     warnings.warn(
                         f'Server default calibration set has changed from {self._calibration_set_id} '
                         f'to {default_calset_id}. Use a new IQMSampler to decompose/route the circuits using '
-                        f'the new calibration set.'
+                        'the new calibration set to ensure successful execution.'
                     )
 
         return self._client.create_run_request(

--- a/src/iqm/cirq_iqm/optimizers.py
+++ b/src/iqm/cirq_iqm/optimizers.py
@@ -49,6 +49,7 @@ def simplify_circuit(
     Returns:
         simplified circuit
     """
+    calset_id = getattr(circuit, 'iqm_calibration_set_id', None)
     c = circuit.copy()
 
     # the optimizers cause the immediate decomposition of any gates they insert into the Circuit
@@ -72,6 +73,7 @@ def simplify_circuit(
 
     DropRZBeforeMeasurement(drop_final=drop_final_rz).optimize_circuit(c)
     c = cirq.drop_empty_moments(c)
+    c.iqm_calibration_set_id = calset_id  # type: ignore
 
     return c
 

--- a/src/iqm/cirq_iqm/transpiler.py
+++ b/src/iqm/cirq_iqm/transpiler.py
@@ -42,10 +42,12 @@ def transpile_insert_moves_into_circuit(
     Returns:
         Transpiled circuit.
     """
+    if device.metadata.architecture is None:
+        raise ValueError("MOVE transpilation only supported for devices created from a dynamic quantum architecture.")
     iqm_client_circuit = serialize_circuit(cirq_circuit)
     new_iqm_client_circuit = transpile_insert_moves(
         iqm_client_circuit,
-        device.metadata.to_architecture(),
+        device.metadata.architecture,
         existing_moves=existing_moves,
         qubit_mapping=qubit_mapping,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ from uuid import UUID
 import pytest
 
 from iqm.cirq_iqm import IQMDevice, IQMDeviceMetadata
-from iqm.iqm_client import QuantumArchitectureSpecification
+from iqm.iqm_client import DynamicQuantumArchitecture, GateImplementationInfo, GateInfo
 
 existing_run = UUID('3c3fcda3-e860-46bf-92a4-bcc59fa76ce9')
 missing_run = UUID('059e4186-50a3-4e6c-ba1f-37fe6afbdfc2')
@@ -32,55 +32,97 @@ def base_url():
     return 'https://example.com'
 
 
-@pytest.fixture()
-def fake_spec_with_resonator():
-    ndonis_architecture_specification = {
-        'name': 'Ndonis',
-        'operations': {
-            'cz': [
-                ['QB1', 'COMP_R'],
-                ['QB2', 'COMP_R'],
-                ['QB3', 'COMP_R'],
-                ['QB4', 'COMP_R'],
-                ['QB5', 'COMP_R'],
-                ['QB6', 'COMP_R'],
-            ],
-            'prx': [['QB1'], ['QB2'], ['QB3'], ['QB4'], ['QB5'], ['QB6']],
-            'move': [
-                ['QB1', 'COMP_R'],
-                ['QB2', 'COMP_R'],
-                ['QB3', 'COMP_R'],
-                ['QB4', 'COMP_R'],
-                ['QB5', 'COMP_R'],
-            ],
-            'barrier': [],
-            'measure': [['QB1'], ['QB2'], ['QB3'], ['QB4'], ['QB5'], ['QB6']],
+@pytest.fixture
+def fake_arch_with_resonator():
+    return DynamicQuantumArchitecture(
+        calibration_set_id=UUID('26c5e70f-bea0-43af-bd37-6212ec7d04cb'),
+        qubits=['QB1', 'QB2', 'QB3', 'QB4', 'QB5', 'QB6'],
+        computational_resonators=['COMP_R'],
+        gates={
+            'prx': GateInfo(
+                implementations={
+                    'drag_gaussian': GateImplementationInfo(
+                        loci=(('QB1',), ('QB2',), ('QB3',), ('QB4',), ('QB5',), ('QB6',))
+                    ),
+                },
+                default_implementation='drag_gaussian',
+                override_default_implementation={},
+            ),
+            'cz': GateInfo(
+                implementations={
+                    'tgss': GateImplementationInfo(
+                        loci=(
+                            ('QB1', 'COMP_R'),
+                            ('QB2', 'COMP_R'),
+                            ('QB3', 'COMP_R'),
+                            ('QB4', 'COMP_R'),
+                            ('QB5', 'COMP_R'),
+                            ('QB6', 'COMP_R'),
+                        )
+                    ),
+                },
+                default_implementation='tgss',
+                override_default_implementation={},
+            ),
+            'move': GateInfo(
+                implementations={
+                    'tgss_crf': GateImplementationInfo(
+                        loci=(
+                            ('QB1', 'COMP_R'),
+                            ('QB2', 'COMP_R'),
+                            ('QB3', 'COMP_R'),
+                            ('QB4', 'COMP_R'),
+                            ('QB5', 'COMP_R'),
+                        )
+                    ),
+                },
+                default_implementation='tgss_crf',
+                override_default_implementation={},
+            ),
+            'measure': GateInfo(
+                implementations={
+                    'constant': GateImplementationInfo(
+                        loci=(('QB1',), ('QB2',), ('QB3',), ('QB4',), ('QB5',), ('QB6',))
+                    ),
+                },
+                default_implementation='constant',
+                override_default_implementation={},
+            ),
         },
-        'qubits': ['COMP_R', 'QB1', 'QB2', 'QB3', 'QB4', 'QB5', 'QB6'],
-        'qubit_connectivity': [
-            ['QB1', 'COMP_R'],
-            ['QB2', 'COMP_R'],
-            ['QB3', 'COMP_R'],
-            ['QB4', 'COMP_R'],
-            ['QB5', 'COMP_R'],
-            ['QB6', 'COMP_R'],
-        ],
-    }
-    return QuantumArchitectureSpecification(**ndonis_architecture_specification)
+    )
 
 
 @pytest.fixture
 def adonis_architecture_shuffled_names():
-    return QuantumArchitectureSpecification(
-        name='Adonis',
-        operations={
-            'prx': [['QB2'], ['QB3'], ['QB1'], ['QB5'], ['QB4']],
-            'cz': [['QB1', 'QB3'], ['QB2', 'QB3'], ['QB4', 'QB3'], ['QB5', 'QB3']],
-            'measure': [['QB2'], ['QB3'], ['QB1'], ['QB5'], ['QB4']],
-            'barrier': [],
-        },
+    return DynamicQuantumArchitecture(
+        calibration_set_id=UUID('26c5e70f-bea0-43af-bd37-6212ec7d04cb'),
         qubits=['QB2', 'QB3', 'QB1', 'QB5', 'QB4'],
-        qubit_connectivity=[['QB1', 'QB3'], ['QB2', 'QB3'], ['QB4', 'QB3'], ['QB5', 'QB3']],
+        computational_resonators=[],
+        gates={
+            'prx': GateInfo(
+                implementations={
+                    'drag_gaussian': GateImplementationInfo(loci=(('QB2',), ('QB3',), ('QB1',), ('QB5',), ('QB4',))),
+                },
+                default_implementation='drag_gaussian',
+                override_default_implementation={},
+            ),
+            'cz': GateInfo(
+                implementations={
+                    'tgss': GateImplementationInfo(
+                        loci=(('QB1', 'QB3'), ('QB2', 'QB3'), ('QB4', 'QB3'), ('QB5', 'QB3'))
+                    ),
+                },
+                default_implementation='tgss',
+                override_default_implementation={},
+            ),
+            'measure': GateInfo(
+                implementations={
+                    'constant': GateImplementationInfo(loci=(('QB2',), ('QB3',), ('QB1',), ('QB5',), ('QB4',)))
+                },
+                default_implementation='constant',
+                override_default_implementation={},
+            ),
+        },
     )
 
 
@@ -91,56 +133,69 @@ def device_without_resonator(adonis_architecture_shuffled_names):
 
 
 @pytest.fixture()
-def device_with_resonator(fake_spec_with_resonator):
+def device_with_resonator(fake_arch_with_resonator):
     """Returns device object created based on architecture specification"""
-    return IQMDevice(IQMDeviceMetadata.from_architecture(fake_spec_with_resonator))
+    return IQMDevice(IQMDeviceMetadata.from_architecture(fake_arch_with_resonator))
 
 
 @pytest.fixture
 def device_with_multiple_resonators():
     """Some fictional 5 qubit device with multiple resonators."""
-    multiple_resonators_specification = {
-        'name': 'MultiResonators',
-        'operations': {
-            'cz': [
-                ['QB1', 'COMP_R0'],
-                ['QB2', 'COMP_R0'],
-                ['QB2', 'COMP_R1'],
-                ['QB3', 'COMP_R1'],
-                ['QB3', 'COMP_R2'],
-                ['QB4', 'COMP_R2'],
-                ['QB4', 'COMP_R3'],
-                ['QB5', 'COMP_R3'],
-                ['QB5', 'COMP_R4'],
-                ['QB1', 'COMP_R4'],
-                ['QB1', 'QB3'],
-            ],
-            'prx': [['QB2'], ['QB3'], ['QB1'], ['QB5'], ['QB4']],
-            'move': [
-                ['QB1', 'COMP_R0'],
-                ['QB2', 'COMP_R1'],
-                ['QB3', 'COMP_R2'],
-                ['QB4', 'COMP_R3'],
-                ['QB5', 'COMP_R4'],
-            ],
-            'barrier': [],
-            'measure': [['QB2'], ['QB3'], ['QB1'], ['QB5'], ['QB4']],
+    multiple_resonators_arch = DynamicQuantumArchitecture(
+        calibration_set_id=UUID('26c5e70f-bea0-43af-bd37-6212ec7d04cb'),
+        qubits=['QB1', 'QB2', 'QB3', 'QB4', 'QB5'],
+        computational_resonators=['COMP_R0', 'COMP_R1', 'COMP_R2', 'COMP_R3', 'COMP_R4'],
+        gates={
+            'prx': GateInfo(
+                implementations={
+                    'drag_gaussian': GateImplementationInfo(loci=(('QB2',), ('QB3',), ('QB1',), ('QB5',), ('QB4',))),
+                },
+                default_implementation='drag_gaussian',
+                override_default_implementation={},
+            ),
+            'cz': GateInfo(
+                implementations={
+                    'tgss': GateImplementationInfo(
+                        loci=(
+                            ('QB1', 'COMP_R0'),
+                            ('QB2', 'COMP_R0'),
+                            ('QB2', 'COMP_R1'),
+                            ('QB3', 'COMP_R1'),
+                            ('QB3', 'COMP_R2'),
+                            ('QB4', 'COMP_R2'),
+                            ('QB4', 'COMP_R3'),
+                            ('QB5', 'COMP_R3'),
+                            ('QB5', 'COMP_R4'),
+                            ('QB1', 'COMP_R4'),
+                            ('QB1', 'QB3'),
+                        )
+                    ),
+                },
+                default_implementation='tgss',
+                override_default_implementation={},
+            ),
+            'move': GateInfo(
+                implementations={
+                    'tgss_crf': GateImplementationInfo(
+                        loci=(
+                            ('QB1', 'COMP_R0'),
+                            ('QB2', 'COMP_R1'),
+                            ('QB3', 'COMP_R2'),
+                            ('QB4', 'COMP_R3'),
+                            ('QB5', 'COMP_R4'),
+                        )
+                    ),
+                },
+                default_implementation='tgss_crf',
+                override_default_implementation={},
+            ),
+            'measure': GateInfo(
+                implementations={
+                    'constant': GateImplementationInfo(loci=(('QB2',), ('QB3',), ('QB1',), ('QB5',), ('QB4',))),
+                },
+                default_implementation='constant',
+                override_default_implementation={},
+            ),
         },
-        'qubits': ['COMP_R0', 'COMP_R1', 'COMP_R2', 'COMP_R3', 'COMP_R4', 'QB1', 'QB2', 'QB3', 'QB4', 'QB5'],
-        'qubit_connectivity': [
-            ['QB1', 'COMP_R0'],
-            ['QB2', 'COMP_R0'],
-            ['QB2', 'COMP_R1'],
-            ['QB3', 'COMP_R1'],
-            ['QB3', 'COMP_R2'],
-            ['QB4', 'COMP_R2'],
-            ['QB4', 'COMP_R3'],
-            ['QB5', 'COMP_R3'],
-            ['QB5', 'COMP_R4'],
-            ['QB1', 'COMP_R4'],
-            ['QB1', 'QB3'],
-        ],
-    }
-    return IQMDevice(
-        IQMDeviceMetadata.from_architecture(QuantumArchitectureSpecification(**multiple_resonators_specification))
     )
+    return IQMDevice(IQMDeviceMetadata.from_architecture(multiple_resonators_arch))

--- a/tests/test_iqm_device.py
+++ b/tests/test_iqm_device.py
@@ -94,6 +94,15 @@ def test_transpilation(device: IQMDevice, request):
     print("Circuit qubits after adding routing qubits:", circuit.all_qubits())
     assert_circuits_have_same_unitary_given_final_permutation(routed_circuit, circuit, qubit_map=qubit_map)
     assert_circuits_have_same_unitary_given_final_permutation(decomposed_routed_circuit, circuit, qubit_map=qubit_map)
+    if device.metadata.architecture is not None:
+        assert routed_circuit.iqm_calibration_set_id == device.metadata.architecture.calibration_set_id  # type: ignore
+        assert (
+            decomposed_routed_circuit.iqm_calibration_set_id  # type: ignore
+            == device.metadata.architecture.calibration_set_id
+        )
+    else:
+        assert routed_circuit.iqm_calibration_set_id is None  # type: ignore
+        assert decomposed_routed_circuit.iqm_calibration_set_id is None  # type: ignore
 
 
 @pytest.mark.parametrize(

--- a/tests/test_iqm_device_metadata.py
+++ b/tests/test_iqm_device_metadata.py
@@ -11,26 +11,46 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from uuid import UUID
 
 import cirq
 
 from iqm.cirq_iqm import IQMDeviceMetadata
-from iqm.iqm_client import QuantumArchitectureSpecification
+from iqm.iqm_client import DynamicQuantumArchitecture, GateImplementationInfo, GateInfo
 
 
 def test_device_metadata_from_architecture():
-    qa = {
-        'name': 'Valkmusa',
-        'operations': [
-            'prx',
-            'measurement',
-        ],
-        'qubits': ['QB1', 'QB2'],
-        'qubit_connectivity': [
-            ['QB1', 'QB2'],
-        ],
-    }
-    metadata = IQMDeviceMetadata.from_architecture(QuantumArchitectureSpecification(**qa))
+    arch = DynamicQuantumArchitecture(
+        calibration_set_id=UUID('26c5e70f-bea0-43af-bd37-6212ec7d04cb'),
+        qubits=['QB1', 'QB2'],
+        computational_resonators=[],
+        gates={
+            'prx': GateInfo(
+                implementations={
+                    'drag_gaussian': GateImplementationInfo(loci=(('QB1',), ('QB2',))),
+                },
+                default_implementation='drag_gaussian',
+                override_default_implementation={},
+            ),
+            'cz': GateInfo(
+                implementations={
+                    'tgss': GateImplementationInfo(loci=(('QB1', 'QB2'),)),
+                },
+                default_implementation='tgss',
+                override_default_implementation={},
+            ),
+            'measure': GateInfo(
+                implementations={
+                    'constant': GateImplementationInfo(loci=(('QB1',), ('QB2',))),
+                },
+                default_implementation='constant',
+                override_default_implementation={},
+            ),
+        },
+    )
+    metadata = IQMDeviceMetadata.from_architecture(arch)
     assert metadata.qubit_set == {cirq.NamedQubit('QB1'), cirq.NamedQubit('QB2')}
     assert [set(e) for e in metadata.nx_graph.edges] == [{cirq.NamedQubit('QB1'), cirq.NamedQubit('QB2')}]
-    assert metadata.gateset == cirq.Gateset(cirq.PhasedXPowGate, cirq.XPowGate, cirq.YPowGate, cirq.MeasurementGate)
+    assert metadata.gateset == cirq.Gateset(
+        cirq.PhasedXPowGate, cirq.XPowGate, cirq.YPowGate, cirq.MeasurementGate, cirq.CZPowGate
+    )

--- a/tests/test_iqm_device_metadata.py
+++ b/tests/test_iqm_device_metadata.py
@@ -14,6 +14,7 @@
 from uuid import UUID
 
 import cirq
+import pytest
 
 from iqm.cirq_iqm import IQMDeviceMetadata
 from iqm.iqm_client import DynamicQuantumArchitecture, GateImplementationInfo, GateInfo
@@ -54,3 +55,14 @@ def test_device_metadata_from_architecture():
     assert metadata.gateset == cirq.Gateset(
         cirq.PhasedXPowGate, cirq.XPowGate, cirq.YPowGate, cirq.MeasurementGate, cirq.CZPowGate
     )
+
+
+def test_device_metadata_qubit_indices_bad_connectivity():
+    with pytest.raises(ValueError, match='connectivity_indices must be an iterable of 2-sets'):
+        IQMDeviceMetadata.from_qubit_indices(3, [{1, 2}, {2, 3}, {1, 2, 3}])
+
+
+def test_device_metadata_init_bad_connectivity():
+    qubits = [cirq.NamedQubit(f'QB{q}') for q in range(3)]
+    with pytest.raises(ValueError, match='Connectivity must be an iterable of 2-tuples'):
+        IQMDeviceMetadata(qubits, [(qubits[0], qubits[1]), (qubits[0], qubits[1], qubits[2])])

--- a/tests/test_iqm_operation_mapping.py
+++ b/tests/test_iqm_operation_mapping.py
@@ -41,7 +41,7 @@ def test_maps_measurement_gate(qubit_1):
     key = 'test measurement'
     operation = GateOperation(MeasurementGate(1, key), [qubit_1])
     mapped = map_operation(operation)
-    expected = Instruction(name='measurement', qubits=(str(qubit_1),), args={'key': key})
+    expected = Instruction(name='measure', qubits=(str(qubit_1),), args={'key': key})
     assert expected == mapped
 
 
@@ -100,7 +100,7 @@ def test_instruction_to_operation():
     assert operation.gate.exponent == 1.0
     assert operation.gate.global_shift == 0.0
 
-    instruction = Instruction(name='measurement', qubits=('QB1',), args={'key': 'test key'})
+    instruction = Instruction(name='measure', qubits=('QB1',), args={'key': 'test key'})
     operation = instruction_to_operation(instruction)
     assert isinstance(operation.gate, MeasurementGate)
     assert operation.qubits == (cirq.NamedQubit('QB1'),)

--- a/tests/test_iqm_sampler.py
+++ b/tests/test_iqm_sampler.py
@@ -502,7 +502,7 @@ def test_run_does_not_warn(
     sampler = IQMSampler(base_url)
     routed_circuit, _, _ = sampler.device.route_circuit(circuit_physical)
 
-    with warnings.catch_warnings(category=UserWarning):
+    with warnings.catch_warnings():
         warnings.simplefilter('error')
         sampler.run(routed_circuit)
 

--- a/tests/test_iqm_sampler.py
+++ b/tests/test_iqm_sampler.py
@@ -46,11 +46,13 @@ from iqm.iqm_client import (
 
 
 @pytest.fixture()
-def circuit_physical():
+def circuit_physical(adonis_architecture):
     """Circuit with physical qubit names"""
     qubit_1 = cirq.NamedQubit('QB1')
     qubit_2 = cirq.NamedQubit('QB2')
-    return cirq.Circuit(cirq.measure(qubit_1, qubit_2, key='result'))
+    circuit = cirq.Circuit(cirq.measure(qubit_1, qubit_2, key='result'))
+    circuit.iqm_calibration_set_id = adonis_architecture.calibration_set_id
+    return circuit
 
 
 @pytest.fixture()
@@ -79,7 +81,8 @@ def iqm_metadata():
 
 
 @pytest.fixture()
-def adonis_sampler(base_url):
+def adonis_sampler(base_url, adonis_architecture):
+    when(IQMClient).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     return IQMSampler(base_url, device=Adonis())
 
 
@@ -119,13 +122,14 @@ def adonis_architecture():
 
 @pytest.fixture()
 def adonis_sampler_from_architecture(base_url, adonis_architecture):
+    when(IQMClient).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     return IQMSampler(base_url, device=IQMDevice(IQMDeviceMetadata.from_architecture(adonis_architecture)))
 
 
 @pytest.fixture
-def create_run_request_default_kwargs() -> dict:
+def create_run_request_default_kwargs(adonis_architecture) -> dict:
     return {
-        'calibration_set_id': None,
+        'calibration_set_id': adonis_architecture.calibration_set_id,
         'shots': 1,
         'options': CircuitCompilationOptions(),
     }
@@ -169,7 +173,18 @@ def test_init_with_calset_id_and_device(base_url, adonis_architecture):
 
 
 @pytest.mark.usefixtures('unstub')
-def test_init_warns_if_device_not_compatible_with_calset(base_url, fake_arch_with_resonator):
+def test_init_warns_if_device_not_compatible_with_default_calset(base_url, fake_arch_with_resonator):
+    when(IQMClient).get_dynamic_quantum_architecture(None).thenReturn(fake_arch_with_resonator)
+    with pytest.raises(
+        ValueError,
+        match="'device' is not compatible with the server default calibration set "
+        f'{fake_arch_with_resonator.calibration_set_id}',
+    ):
+        IQMSampler(base_url, device=Adonis())
+
+
+@pytest.mark.usefixtures('unstub')
+def test_init_warns_if_device_not_compatible_with_calset_id(base_url, fake_arch_with_resonator):
     calset_id = uuid.uuid4()
     when(IQMClient).get_dynamic_quantum_architecture(calset_id).thenReturn(fake_arch_with_resonator)
     with pytest.raises(ValueError, match=f"'device' is not compatible with calibration set {calset_id}"):
@@ -179,9 +194,7 @@ def test_init_warns_if_device_not_compatible_with_calset(base_url, fake_arch_wit
 @pytest.mark.usefixtures('unstub')
 def test_run_sweep_raises_with_non_physical_names(adonis_sampler_from_architecture, circuit_non_physical):
     sampler = adonis_sampler_from_architecture
-    when(sampler._client).get_dynamic_quantum_architecture(sampler._calibration_set_id).thenReturn(
-        sampler.device.metadata.architecture
-    )
+    when(sampler._client).get_dynamic_quantum_architecture(ANY).thenReturn(sampler.device.metadata.architecture)
     # Note that validation is done in iqm_client, so this is now an integration test.
     with pytest.raises(CircuitValidationError, match="Alice is not allowed as locus for 'measure'"):
         sampler.run_sweep(circuit_non_physical, None)
@@ -189,10 +202,17 @@ def test_run_sweep_raises_with_non_physical_names(adonis_sampler_from_architectu
 
 @pytest.mark.usefixtures('unstub')
 def test_run_sweep_executes_circuit_with_physical_names(
-    adonis_sampler, circuit_physical, iqm_metadata, create_run_request_default_kwargs, job_id, run_request
+    adonis_sampler,
+    adonis_architecture,
+    circuit_physical,
+    iqm_metadata,
+    create_run_request_default_kwargs,
+    job_id,
+    run_request,
 ):
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     client = mock(IQMClient)
+    when(client).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     run_result = RunResult(status=Status.READY, measurements=[{'some stuff': [[0], [1]]}], metadata=iqm_metadata)
     when(client).create_run_request(ANY, **create_run_request_default_kwargs).thenReturn(run_request)
     when(client).submit_run_request(run_request).thenReturn(job_id)
@@ -235,16 +255,24 @@ def test_run_sweep_executes_circuit_with_calibration_set_id(
 
 @pytest.mark.usefixtures('unstub')
 def test_run_sweep_has_duration_check_enabled_by_default(
-    base_url, circuit_physical, iqm_metadata, create_run_request_default_kwargs, job_id, run_request
+    base_url,
+    adonis_architecture,
+    circuit_physical,
+    iqm_metadata,
+    create_run_request_default_kwargs,
+    job_id,
+    run_request,
 ):
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     client = mock(IQMClient)
+    when(IQMClient).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     sampler = IQMSampler(base_url, device=Adonis())
     run_result = RunResult(status=Status.READY, measurements=[{'some stuff': [[0], [1]]}], metadata=iqm_metadata)
     assert sampler._compiler_options.max_circuit_duration_over_t2 is None
     kwargs = create_run_request_default_kwargs | {
         'options': CircuitCompilationOptions(max_circuit_duration_over_t2=None)
     }
+    when(client).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     when(client).create_run_request(ANY, **kwargs).thenReturn(run_request)
     when(client).submit_run_request(run_request).thenReturn(job_id)
     when(client).wait_for_results(job_id).thenReturn(run_result)
@@ -258,10 +286,17 @@ def test_run_sweep_has_duration_check_enabled_by_default(
 
 @pytest.mark.usefixtures('unstub')
 def test_run_sweep_executes_circuit_with_duration_check_disabled(
-    base_url, circuit_physical, iqm_metadata, create_run_request_default_kwargs, job_id, run_request
+    base_url,
+    adonis_architecture,
+    circuit_physical,
+    iqm_metadata,
+    create_run_request_default_kwargs,
+    job_id,
+    run_request,
 ):
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     client = mock(IQMClient)
+    when(IQMClient).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     sampler = IQMSampler(
         base_url, device=Adonis(), compiler_options=CircuitCompilationOptions(max_circuit_duration_over_t2=0.0)
     )
@@ -270,6 +305,7 @@ def test_run_sweep_executes_circuit_with_duration_check_disabled(
     kwargs = create_run_request_default_kwargs | {
         'options': CircuitCompilationOptions(max_circuit_duration_over_t2=0.0)
     }
+    when(client).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     when(client).create_run_request(ANY, **kwargs).thenReturn(run_request)
     when(client).submit_run_request(run_request).thenReturn(job_id)
     when(client).wait_for_results(job_id).thenReturn(run_result)
@@ -283,13 +319,21 @@ def test_run_sweep_executes_circuit_with_duration_check_disabled(
 
 @pytest.mark.usefixtures('unstub')
 def test_run_sweep_allows_to_override_polling_timeout(
-    base_url, circuit_physical, create_run_request_default_kwargs, iqm_metadata, job_id, run_request
+    base_url,
+    adonis_architecture,
+    circuit_physical,
+    create_run_request_default_kwargs,
+    iqm_metadata,
+    job_id,
+    run_request,
 ):
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     client = mock(IQMClient)
     timeout = 123
+    when(IQMClient).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     sampler = IQMSampler(base_url, device=Adonis(), run_sweep_timeout=timeout)
     run_result = RunResult(status=Status.READY, measurements=[{'some stuff': [[0], [1]]}], metadata=iqm_metadata)
+    when(client).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     when(client).create_run_request(ANY, **create_run_request_default_kwargs).thenReturn(run_request)
     when(client).submit_run_request(run_request).thenReturn(job_id)
     when(client).wait_for_results(job_id, timeout).thenReturn(run_result)
@@ -303,14 +347,22 @@ def test_run_sweep_allows_to_override_polling_timeout(
 
 @pytest.mark.usefixtures('unstub')
 def test_run_sweep_has_heralding_mode_none_by_default(
-    base_url, circuit_physical, iqm_metadata, create_run_request_default_kwargs, job_id, run_request
+    base_url,
+    adonis_architecture,
+    circuit_physical,
+    iqm_metadata,
+    create_run_request_default_kwargs,
+    job_id,
+    run_request,
 ):
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     client = mock(IQMClient)
+    when(IQMClient).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     sampler = IQMSampler(base_url, device=Adonis())
     run_result = RunResult(status=Status.READY, measurements=[{'some stuff': [[0], [1]]}], metadata=iqm_metadata)
     kwargs = create_run_request_default_kwargs
     assert sampler._compiler_options.heralding_mode == HeraldingMode.NONE
+    when(client).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     when(client).create_run_request(ANY, **kwargs).thenReturn(run_request)
     when(client).submit_run_request(run_request).thenReturn(job_id)
     when(client).wait_for_results(job_id).thenReturn(run_result)
@@ -324,10 +376,17 @@ def test_run_sweep_has_heralding_mode_none_by_default(
 
 @pytest.mark.usefixtures('unstub')
 def test_run_sweep_executes_circuit_with_heralding_mode_zeros(
-    base_url, circuit_physical, iqm_metadata, create_run_request_default_kwargs, job_id, run_request
+    base_url,
+    adonis_architecture,
+    circuit_physical,
+    iqm_metadata,
+    create_run_request_default_kwargs,
+    job_id,
+    run_request,
 ):
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     client = mock(IQMClient)
+    when(IQMClient).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     sampler = IQMSampler(
         base_url, device=Adonis(), compiler_options=CircuitCompilationOptions(heralding_mode=HeraldingMode.ZEROS)
     )
@@ -336,10 +395,7 @@ def test_run_sweep_executes_circuit_with_heralding_mode_zeros(
         'options': CircuitCompilationOptions(heralding_mode=HeraldingMode.ZEROS)
     }
     assert sampler._compiler_options.heralding_mode == HeraldingMode.ZEROS
-    kwargs = create_run_request_default_kwargs | {
-        'options': CircuitCompilationOptions(heralding_mode=HeraldingMode.ZEROS)
-    }
-    assert sampler._compiler_options.heralding_mode == HeraldingMode.ZEROS
+    when(client).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     when(client).create_run_request(ANY, **kwargs).thenReturn(run_request)
     when(client).submit_run_request(run_request).thenReturn(job_id)
     when(client).wait_for_results(job_id).thenReturn(run_result)
@@ -353,12 +409,14 @@ def test_run_sweep_executes_circuit_with_heralding_mode_zeros(
 
 @pytest.mark.usefixtures('unstub')
 def test_run_sweep_with_parameter_sweep(
-    adonis_sampler, iqm_metadata, create_run_request_default_kwargs, job_id, run_request
+    adonis_sampler, adonis_architecture, iqm_metadata, create_run_request_default_kwargs, job_id, run_request
 ):
+    # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
     client = mock(IQMClient)
     run_result = RunResult(
         status=Status.READY, measurements=[{'some stuff': [[0]]}, {'some stuff': [[1]]}], metadata=iqm_metadata
     )
+    when(client).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     when(client).create_run_request(ANY, **create_run_request_default_kwargs).thenReturn(run_request)
     when(client).submit_run_request(run_request).thenReturn(job_id)
     when(client).wait_for_results(job_id).thenReturn(run_result)
@@ -383,10 +441,17 @@ def test_run_sweep_with_parameter_sweep(
 
 @pytest.mark.usefixtures('unstub')
 def test_run_sweep_abort_job_successful(
-    adonis_sampler, circuit_physical, create_run_request_default_kwargs, job_id, recwarn, run_request
+    adonis_sampler,
+    adonis_architecture,
+    circuit_physical,
+    create_run_request_default_kwargs,
+    job_id,
+    recwarn,
+    run_request,
 ):
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     client = mock(IQMClient)
+    when(client).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     when(client).create_run_request(ANY, **create_run_request_default_kwargs).thenReturn(run_request)
     when(client).submit_run_request(run_request).thenReturn(job_id)
     when(client).wait_for_results(job_id).thenRaise(KeyboardInterrupt)
@@ -404,9 +469,11 @@ def test_run_sweep_abort_job_successful(
 
 @pytest.mark.usefixtures('unstub')
 def test_run_sweep_abort_job_failed(
-    adonis_sampler, circuit_physical, create_run_request_default_kwargs, job_id, run_request
+    adonis_sampler, adonis_architecture, circuit_physical, create_run_request_default_kwargs, job_id, run_request
 ):
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     client = mock(IQMClient)
+    when(client).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     when(client).create_run_request(ANY, **create_run_request_default_kwargs).thenReturn(run_request)
     when(client).submit_run_request(run_request).thenReturn(job_id)
     when(client).wait_for_results(job_id).thenRaise(KeyboardInterrupt)
@@ -425,9 +492,7 @@ def test_run_sweep_abort_job_failed(
 @pytest.mark.usefixtures('unstub')
 def test_run_iqm_batch_raises_with_non_physical_names(adonis_sampler_from_architecture, circuit_non_physical):
     sampler = adonis_sampler_from_architecture
-    when(sampler._client).get_dynamic_quantum_architecture(sampler._calibration_set_id).thenReturn(
-        sampler.device.metadata.architecture
-    )
+    when(sampler._client).get_dynamic_quantum_architecture(ANY).thenReturn(sampler.device.metadata.architecture)
     # Note that validation is done in iqm_client, so this is now an integration test.
     with pytest.raises(CircuitValidationError, match="Alice is not allowed as locus for 'measure'"):
         sampler.run_iqm_batch([circuit_non_physical])
@@ -436,13 +501,14 @@ def test_run_iqm_batch_raises_with_non_physical_names(adonis_sampler_from_archit
 
 
 @pytest.mark.usefixtures('unstub')
-def test_run(adonis_sampler, iqm_metadata, create_run_request_default_kwargs, job_id):
+def test_run(adonis_sampler, adonis_architecture, iqm_metadata, create_run_request_default_kwargs, job_id):
     client = mock(IQMClient)
     repetitions = 123
     run_result = RunResult(
         status=Status.READY, measurements=[{'some stuff': [[0]]}, {'some stuff': [[1]]}], metadata=iqm_metadata
     )
     kwargs = create_run_request_default_kwargs | {'shots': repetitions}
+    when(client).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     when(client).create_run_request(ANY, **kwargs).thenReturn(run_request)
     when(client).submit_run_request(run_request).thenReturn(job_id)
     when(client).wait_for_results(job_id).thenReturn(run_result)
@@ -460,9 +526,14 @@ def test_run(adonis_sampler, iqm_metadata, create_run_request_default_kwargs, jo
 
 
 @pytest.mark.usefixtures('unstub')
-def test_run_ndonis(device_with_resonator, base_url, iqm_metadata, create_run_request_default_kwargs, job_id):
+def test_run_ndonis(
+    device_with_resonator, fake_arch_with_resonator, base_url, iqm_metadata, create_run_request_default_kwargs, job_id
+):
+    # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+    when(IQMClient).get_dynamic_quantum_architecture(None).thenReturn(fake_arch_with_resonator)
     sampler = IQMSampler(base_url, device=device_with_resonator)
     client = mock(IQMClient)
+    when(client).get_dynamic_quantum_architecture(None).thenReturn(fake_arch_with_resonator)
     repetitions = 123
     run_result = RunResult(
         status=Status.READY, measurements=[{'some stuff': [[0]]}, {'some stuff': [[1]]}], metadata=iqm_metadata
@@ -598,13 +669,17 @@ def test_run_warns_if_circuits_routed_with_different_calset_id(
 
 
 @pytest.mark.usefixtures('unstub')
-def test_run_iqm_batch(adonis_sampler, iqm_metadata, create_run_request_default_kwargs, job_id, run_request):
+def test_run_iqm_batch(
+    adonis_sampler, adonis_architecture, iqm_metadata, create_run_request_default_kwargs, job_id, run_request
+):
+    # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
     client = mock(IQMClient)
     repetitions = 123
     run_result = RunResult(
         status=Status.READY, measurements=[{'some stuff': [[0]]}, {'some stuff': [[1]]}], metadata=iqm_metadata
     )
     kwargs = create_run_request_default_kwargs | {'shots': repetitions}
+    when(client).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     when(client).create_run_request(ANY, **kwargs).thenReturn(run_request)
     when(client).submit_run_request(run_request).thenReturn(job_id)
     when(client).wait_for_results(job_id).thenReturn(run_result)
@@ -627,14 +702,17 @@ def test_run_iqm_batch(adonis_sampler, iqm_metadata, create_run_request_default_
 
 @pytest.mark.usefixtures('unstub')
 def test_run_iqm_batch_allows_to_override_polling_timeout(
-    base_url, iqm_metadata, create_run_request_default_kwargs, job_id, run_request
+    base_url, adonis_architecture, iqm_metadata, create_run_request_default_kwargs, job_id, run_request
 ):
+    # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
     client = mock(IQMClient)
+    when(IQMClient).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     run_result = RunResult(
         status=Status.READY, measurements=[{'some stuff': [[0]]}, {'some stuff': [[1]]}], metadata=iqm_metadata
     )
     timeout = 123
     sampler = IQMSampler(base_url, device=Adonis(), run_sweep_timeout=timeout)
+    when(client).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     when(client).create_run_request(ANY, **create_run_request_default_kwargs).thenReturn(run_request)
     when(client).submit_run_request(run_request).thenReturn(job_id)
     when(client).wait_for_results(job_id, timeout).thenReturn(run_result)
@@ -655,33 +733,37 @@ def test_run_iqm_batch_allows_to_override_polling_timeout(
 
 
 @pytest.mark.usefixtures('unstub')
-def test_credentials_are_passed_to_client():
+def test_credentials_are_passed_to_client(adonis_architecture):
     user_auth_args = {
         'auth_server_url': 'https://fake.auth.server.com',
         'username': 'fake-username',
         'password': 'fake-password',
     }
+    mock_client = mock(IQMClient)
     when(module_under_test.iqm_sampler).IQMClient('http://url', client_signature=ANY, **user_auth_args).thenReturn(
-        mock(IQMClient)
+        mock_client
     )
+    when(mock_client).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     IQMSampler('http://url', device=Adonis(), **user_auth_args)
     verify(module_under_test.iqm_sampler, times=1).IQMClient('http://url', client_signature=ANY, **user_auth_args)
 
 
 @pytest.mark.usefixtures('unstub')
-def test_client_signature_is_passed_to_client():
+def test_client_signature_is_passed_to_client(adonis_architecture):
     """Test that IQMSampler set client signature"""
+    when(IQMClient).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     sampler = IQMSampler('http://some-url.iqm.fi', device=Adonis())
     assert f'cirq-iqm {version("cirq-iqm")}' in sampler._client._signature
 
 
 @pytest.mark.usefixtures('unstub')
-def test_close_client():
+def test_close_client(adonis_architecture):
     user_auth_args = {
         'auth_server_url': 'https://fake.auth.server.com',
         'username': 'fake-username',
         'password': 'fake-password',
     }
+    when(IQMClient).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     sampler = IQMSampler('http://url', device=Adonis(), **user_auth_args)
     mock_client = mock(IQMClient)
     sampler._client = mock_client
@@ -692,8 +774,9 @@ def test_close_client():
 
 @pytest.mark.usefixtures('unstub')
 def test_create_run_request_for_run(
-    adonis_sampler, iqm_metadata, job_id, create_run_request_default_kwargs, run_request
+    adonis_sampler, adonis_architecture, iqm_metadata, job_id, create_run_request_default_kwargs, run_request
 ):
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     client = mock(IQMClient)
     adonis_sampler._client = client
     repetitions = 123
@@ -709,6 +792,7 @@ def test_create_run_request_for_run(
         [serialize_circuit(circuit)],
         **kwargs,
     ).thenReturn(run_request)
+    when(client).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     when(client).submit_run_request(run_request).thenReturn(job_id)
     when(client).wait_for_results(job_id).thenReturn(run_result)
 
@@ -720,9 +804,9 @@ def test_create_run_request_for_run(
 
 @pytest.mark.usefixtures('unstub')
 def test_create_run_request_for_run_iqm_batch(
-    adonis_sampler, iqm_metadata, job_id, create_run_request_default_kwargs, run_request
+    adonis_sampler, adonis_architecture, iqm_metadata, job_id, create_run_request_default_kwargs, run_request
 ):
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals,too-many-arguments,too-many-positional-arguments
     client = mock(IQMClient)
     adonis_sampler._client = client
     repetitions = 123
@@ -743,6 +827,7 @@ def test_create_run_request_for_run_iqm_batch(
         [serialize_circuit(c) for c in circuits],
         **kwargs,
     ).thenReturn(run_request)
+    when(client).get_dynamic_quantum_architecture(None).thenReturn(adonis_architecture)
     when(client).submit_run_request(run_request).thenReturn(job_id)
     when(client).wait_for_results(job_id).thenReturn(run_result)
 

--- a/tests/test_iqm_sampler.py
+++ b/tests/test_iqm_sampler.py
@@ -172,7 +172,7 @@ def test_run_sweep_raises_with_non_physical_names(adonis_sampler_from_architectu
         sampler.device.metadata.architecture
     )
     # Note that validation is done in iqm_client, so this is now an integration test.
-    with pytest.raises(CircuitValidationError, match='Qubit Alice is not allowed as locus for measure'):
+    with pytest.raises(CircuitValidationError, match="Alice is not allowed as locus for 'measure'"):
         sampler.run_sweep(circuit_non_physical, None)
 
 
@@ -416,11 +416,10 @@ def test_run_iqm_batch_raises_with_non_physical_names(adonis_sampler_from_archit
         sampler.device.metadata.architecture
     )
     # Note that validation is done in iqm_client, so this is now an integration test.
-    with pytest.raises(CircuitValidationError, match='Qubit Alice is not allowed as locus for measure'):
+    with pytest.raises(CircuitValidationError, match="Alice is not allowed as locus for 'measure'"):
         sampler.run_iqm_batch([circuit_non_physical])
 
     verifyNoUnwantedInteractions()
-    unstub()
 
 
 @pytest.mark.usefixtures('unstub')

--- a/tests/test_iqm_sampler.py
+++ b/tests/test_iqm_sampler.py
@@ -18,7 +18,7 @@ import uuid
 import warnings
 
 import cirq
-from mockito import ANY, expect, mock, unstub, verify, verifyNoUnwantedInteractions, when
+from mockito import ANY, expect, mock, verify, verifyNoUnwantedInteractions, when
 import numpy as np
 import pytest
 import sympy  # type: ignore

--- a/tests/test_iqm_sampler.py
+++ b/tests/test_iqm_sampler.py
@@ -80,7 +80,7 @@ def iqm_metadata():
 
 @pytest.fixture()
 def adonis_sampler(base_url):
-    return IQMSampler(base_url, Adonis())
+    return IQMSampler(base_url, device=Adonis())
 
 
 @pytest.fixture()
@@ -119,7 +119,7 @@ def adonis_architecture():
 
 @pytest.fixture()
 def adonis_sampler_from_architecture(base_url, adonis_architecture):
-    return IQMSampler(base_url, IQMDevice(IQMDeviceMetadata.from_architecture(adonis_architecture)))
+    return IQMSampler(base_url, device=IQMDevice(IQMDeviceMetadata.from_architecture(adonis_architecture)))
 
 
 @pytest.fixture
@@ -206,7 +206,7 @@ def test_run_sweep_executes_circuit_with_calibration_set_id(
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     client = mock(IQMClient)
     calibration_set_id = uuid.uuid4()
-    sampler = IQMSampler(base_url, Adonis(), calibration_set_id=calibration_set_id)
+    sampler = IQMSampler(base_url, device=Adonis(), calibration_set_id=calibration_set_id)
     run_result = RunResult(status=Status.READY, measurements=[{'some stuff': [[0], [1]]}], metadata=iqm_metadata)
     kwargs = create_run_request_default_kwargs | {'calibration_set_id': calibration_set_id}
     when(client).create_run_request(ANY, **kwargs).thenReturn(run_request)
@@ -226,7 +226,7 @@ def test_run_sweep_has_duration_check_enabled_by_default(
 ):
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     client = mock(IQMClient)
-    sampler = IQMSampler(base_url, Adonis())
+    sampler = IQMSampler(base_url, device=Adonis())
     run_result = RunResult(status=Status.READY, measurements=[{'some stuff': [[0], [1]]}], metadata=iqm_metadata)
     assert sampler._compiler_options.max_circuit_duration_over_t2 is None
     kwargs = create_run_request_default_kwargs | {
@@ -250,7 +250,7 @@ def test_run_sweep_executes_circuit_with_duration_check_disabled(
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     client = mock(IQMClient)
     sampler = IQMSampler(
-        base_url, Adonis(), compiler_options=CircuitCompilationOptions(max_circuit_duration_over_t2=0.0)
+        base_url, device=Adonis(), compiler_options=CircuitCompilationOptions(max_circuit_duration_over_t2=0.0)
     )
     run_result = RunResult(status=Status.READY, measurements=[{'some stuff': [[0], [1]]}], metadata=iqm_metadata)
     assert sampler._compiler_options.max_circuit_duration_over_t2 == 0.0
@@ -275,7 +275,7 @@ def test_run_sweep_allows_to_override_polling_timeout(
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     client = mock(IQMClient)
     timeout = 123
-    sampler = IQMSampler(base_url, Adonis(), run_sweep_timeout=timeout)
+    sampler = IQMSampler(base_url, device=Adonis(), run_sweep_timeout=timeout)
     run_result = RunResult(status=Status.READY, measurements=[{'some stuff': [[0], [1]]}], metadata=iqm_metadata)
     when(client).create_run_request(ANY, **create_run_request_default_kwargs).thenReturn(run_request)
     when(client).submit_run_request(run_request).thenReturn(job_id)
@@ -294,7 +294,7 @@ def test_run_sweep_has_heralding_mode_none_by_default(
 ):
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     client = mock(IQMClient)
-    sampler = IQMSampler(base_url, Adonis())
+    sampler = IQMSampler(base_url, device=Adonis())
     run_result = RunResult(status=Status.READY, measurements=[{'some stuff': [[0], [1]]}], metadata=iqm_metadata)
     kwargs = create_run_request_default_kwargs
     assert sampler._compiler_options.heralding_mode == HeraldingMode.NONE
@@ -316,7 +316,7 @@ def test_run_sweep_executes_circuit_with_heralding_mode_zeros(
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     client = mock(IQMClient)
     sampler = IQMSampler(
-        base_url, Adonis(), compiler_options=CircuitCompilationOptions(heralding_mode=HeraldingMode.ZEROS)
+        base_url, device=Adonis(), compiler_options=CircuitCompilationOptions(heralding_mode=HeraldingMode.ZEROS)
     )
     run_result = RunResult(status=Status.READY, measurements=[{'some stuff': [[0], [1]]}], metadata=iqm_metadata)
     kwargs = create_run_request_default_kwargs | {
@@ -621,7 +621,7 @@ def test_run_iqm_batch_allows_to_override_polling_timeout(
         status=Status.READY, measurements=[{'some stuff': [[0]]}, {'some stuff': [[1]]}], metadata=iqm_metadata
     )
     timeout = 123
-    sampler = IQMSampler(base_url, Adonis(), run_sweep_timeout=timeout)
+    sampler = IQMSampler(base_url, device=Adonis(), run_sweep_timeout=timeout)
     when(client).create_run_request(ANY, **create_run_request_default_kwargs).thenReturn(run_request)
     when(client).submit_run_request(run_request).thenReturn(job_id)
     when(client).wait_for_results(job_id, timeout).thenReturn(run_result)
@@ -651,14 +651,14 @@ def test_credentials_are_passed_to_client():
     when(module_under_test.iqm_sampler).IQMClient('http://url', client_signature=ANY, **user_auth_args).thenReturn(
         mock(IQMClient)
     )
-    IQMSampler('http://url', Adonis(), **user_auth_args)
+    IQMSampler('http://url', device=Adonis(), **user_auth_args)
     verify(module_under_test.iqm_sampler, times=1).IQMClient('http://url', client_signature=ANY, **user_auth_args)
 
 
 @pytest.mark.usefixtures('unstub')
 def test_client_signature_is_passed_to_client():
     """Test that IQMSampler set client signature"""
-    sampler = IQMSampler('http://some-url.iqm.fi', Adonis())
+    sampler = IQMSampler('http://some-url.iqm.fi', device=Adonis())
     assert f'cirq-iqm {version("cirq-iqm")}' in sampler._client._signature
 
 
@@ -669,7 +669,7 @@ def test_close_client():
         'username': 'fake-username',
         'password': 'fake-password',
     }
-    sampler = IQMSampler('http://url', Adonis(), **user_auth_args)
+    sampler = IQMSampler('http://url', device=Adonis(), **user_auth_args)
     mock_client = mock(IQMClient)
     sampler._client = mock_client
     when(mock_client).close_auth_session().thenReturn(True)

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -151,7 +151,7 @@ class TestSimplifyCircuit:
             [
                 cirq.ZPowGate(exponent=0.1)(q0),
                 cirq.ZPowGate(exponent=0.2)(q1),
-                cirq.MeasurementGate(1, key='measurement')(q0),
+                cirq.MeasurementGate(1, key='measure')(q0),
             ]
         )
         new = simplify_circuit(c)
@@ -168,7 +168,7 @@ class TestSimplifyCircuit:
             [
                 (cirq.X**0.4)(q0),
                 cirq.ZPowGate(exponent=0.1)(q1),
-                cirq.MeasurementGate(1, key='measurement')(q1),
+                cirq.MeasurementGate(1, key='measure')(q1),
                 cirq.ZPowGate(exponent=0.2)(q2),
             ]
         )
@@ -196,7 +196,7 @@ class TestSimplifyCircuit:
             [
                 (cirq.X**0.4)(q0),
                 cirq.ZPowGate(exponent=0.1)(q1),  # Rz followed by measurement
-                cirq.MeasurementGate(1, key='measurement')(q1),
+                cirq.MeasurementGate(1, key='measure')(q1),
                 cirq.ZPowGate(exponent=0.2)(q2),  # final Rz
             ]
         )


### PR DESCRIPTION
- IQMDeviceMetadata can now be created from a DQA, and creating it from QuantumArchitectureSpecification (static architecture) is no longer supported.

- IQMDevice/IQMDeviceMetadata can still be created independently of the architecture/calset, so the hardcoded Adonis, Apollo etc. classes are not removed. They are currently used mainly for tests, and could be used for simulation.

- IQMSampler uses the specified calset (or server default calset if `calibration_set_id` not specified) to create the IQMDeviceMetadata/IQMDevice.

-  IQMSampler adds the calset id to the circuits it decomposes/routes. The calset id is used to warn the user of mismatches between the calset used for execution and the decomposed/routed circuits.

- Requires https://github.com/iqm-finland/iqm-client/pull/140 to be merged first, tests will fail until then. I have tested locally that all tests pass when used together with those changes.