### PR TITLE
Reflect Resonance authentication better in documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 15.4
+============
+
+* Updated the documentation. `#144 <https://github.com/iqm-finland/cirq-on-iqm/pull/144>`_
+
 Version 15.3
 ============
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -259,9 +259,8 @@ Running on a real quantum computer
 
 .. note::
 
-   At the moment IQM does not provide a quantum computing service open to the general public.
-   Please contact our `sales team <https://www.meetiqm.com/contact-us/>`_ to set up your access to
-   an IQM quantum computer.
+   You can access IQM quantum computers via `IQM Resonance <https://www.meetiqm.com/products/iqm-resonance>`_ 
+   or via one of the IQM quantum computers deployed at HPC centers and research institutions around the globe.
 
 Cirq contains various simulators which you can use to simulate the circuits constructed above.
 In this subsection we demonstrate how to run them on an IQM quantum computer.
@@ -354,6 +353,9 @@ as explained in the :ref:`routing` section above.
 Authentication
 ^^^^^^^^^^^^^^
 
+IQM Server (on-premise devices)
+"""""""""""""""""""""""""""""""
+
 If the IQM server you are connecting to requires authentication, you may use
 `Cortex CLI <https://github.com/iqm-finland/cortex-cli>`_ to retrieve and automatically refresh access tokens,
 then set the :envvar:`IQM_TOKENS_FILE` environment variable, as instructed, to point to the tokens file.
@@ -364,9 +366,14 @@ Alternatively, you may authenticate yourself using the :envvar:`IQM_AUTH_SERVER`
 arguments to :class:`.IQMSampler`, but this approach is less secure and
 considered deprecated.
 
-Finally, if you are using ``IQM Resonance``, authentication is handled differently.
-Use the :envvar:`IQM_TOKEN` environment variable to provide the API Token obtained
-from the server dashboard.
+IQM Resonance
+"""""""""""""
+If you are using ``IQM Resonance``, you have two options to authenticate:
+
+1. Set the :envvar:`IQM_TOKEN` environment variable with the API token obtained from the IQM Resonance dashboard.
+2. Pass the `token` parameter to :class:`.IQMSampler`. This will be forwarded to `IQM Client <https://iqm-finland.github.io/docs/iqm-client/>`_, 
+   i.e. `IQMSampler(server_url, token="<YOUR_API_TOKEN>")`
+
 
 
 Batch execution

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -260,7 +260,7 @@ Running on a real quantum computer
 .. note::
 
    You can access IQM quantum computers via `IQM Resonance <https://www.meetiqm.com/products/iqm-resonance>`_
-   or via one of the IQM quantum computers deployed at HPC centers and research institutions around the globe.
+   or use one of the IQM quantum computers deployed at HPC centers and research institutions around the globe.
 
 Cirq contains various simulators which you can use to simulate the circuits constructed above.
 In this subsection we demonstrate how to run them on an IQM quantum computer.

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -259,7 +259,7 @@ Running on a real quantum computer
 
 .. note::
 
-   You can access IQM quantum computers via `IQM Resonance <https://www.meetiqm.com/products/iqm-resonance>`_ 
+   You can access IQM quantum computers via `IQM Resonance <https://www.meetiqm.com/products/iqm-resonance>`_
    or via one of the IQM quantum computers deployed at HPC centers and research institutions around the globe.
 
 Cirq contains various simulators which you can use to simulate the circuits constructed above.
@@ -353,8 +353,17 @@ as explained in the :ref:`routing` section above.
 Authentication
 ^^^^^^^^^^^^^^
 
-IQM Server (on-premise devices)
-"""""""""""""""""""""""""""""""
+IQM Resonance
+"""""""""""""
+
+If you are using IQM Resonance, you have two options to authenticate:
+
+1. Set the :envvar:`IQM_TOKEN` environment variable with the API token obtained from the Resonance dashboard.
+2. Pass the ``token`` parameter to :class:`.IQMSampler`. This will be forwarded to
+   :class:`~iqm.iqm_client.iqm_client.IQMClient`.
+
+On-premises devices
+"""""""""""""""""""
 
 If the IQM server you are connecting to requires authentication, you may use
 `Cortex CLI <https://github.com/iqm-finland/cortex-cli>`_ to retrieve and automatically refresh access tokens,
@@ -365,15 +374,6 @@ Alternatively, you may authenticate yourself using the :envvar:`IQM_AUTH_SERVER`
 :envvar:`IQM_AUTH_USERNAME` and :envvar:`IQM_AUTH_PASSWORD` environment variables, or pass them as
 arguments to :class:`.IQMSampler`, but this approach is less secure and
 considered deprecated.
-
-IQM Resonance
-"""""""""""""
-If you are using ``IQM Resonance``, you have two options to authenticate:
-
-1. Set the :envvar:`IQM_TOKEN` environment variable with the API token obtained from the IQM Resonance dashboard.
-2. Pass the `token` parameter to :class:`.IQMSampler`. This will be forwarded to `IQM Client <https://iqm-finland.github.io/docs/iqm-client/>`_, 
-   i.e. `IQMSampler(server_url, token="<YOUR_API_TOKEN>")`
-
 
 
 Batch execution

--- a/src/iqm/cirq_iqm/iqm_sampler.py
+++ b/src/iqm/cirq_iqm/iqm_sampler.py
@@ -35,8 +35,13 @@ from iqm.iqm_client import CircuitCompilationOptions, IQMClient, JobAbortionErro
 class IQMSampler(cirq.work.Sampler):
     """Circuit sampler for executing quantum circuits on IQM quantum computers.
 
+    IQMSampler connects to a quantum computer through an IQM server.
+    If the server requires user authentication, you can provide it either using environment
+    variables, or as keyword arguments to IQMSampler. The user authentication kwargs are passed
+    through to :class:`~iqm.iqm_client.iqm_client.IQMClient` as is, and are documented there.
+
     Args:
-        url: Endpoint for accessing the server interface. Has to start with http or https.
+        url: URL of the IQM server. Has to start with http or https.
         device: Device to execute the circuits on. If ``None``, the device will be created based
             on the calibration-specific dynamic quantum architecture obtained from
             :class:`~iqm.iqm_client.iqm_client.IQMClient`.
@@ -45,16 +50,6 @@ class IQMSampler(cirq.work.Sampler):
         run_sweep_timeout:
             Timeout for polling sweep results, in seconds. If ``None``, use the client default value.
         compiler_options: The compilation options to use for the circuits, as defined by IQM Client.
-
-    Keyword Args:
-        auth_server_url (str): URL of user authentication server, if required by the IQM Cortex server. It is not required for IQM Resonance.
-            This can also be set in the IQM_AUTH_SERVER environment variable.
-        username (str): Username, if required by the IQM Cortex server. It is not required for IQM Resonance.
-            This can also be set in the IQM_AUTH_USERNAME environment variable.
-        password (str): Password, if required by the IQM Cortex server.
-            This can also be set in the IQM_AUTH_PASSWORD environment variable. It is not required for IQM Resonance.
-        token: API token retrieved from IQM Resonance, not required for on-premise quantum computers.
-            Can also be set in the ``IQM_TOKEN`` environment variable.
     """
 
     def __init__(

--- a/src/iqm/cirq_iqm/iqm_sampler.py
+++ b/src/iqm/cirq_iqm/iqm_sampler.py
@@ -47,12 +47,14 @@ class IQMSampler(cirq.work.Sampler):
         compiler_options: The compilation options to use for the circuits, as defined by IQM Client.
 
     Keyword Args:
-        auth_server_url (str): URL of user authentication server, if required by the IQM Cortex server.
+        auth_server_url (str): URL of user authentication server, if required by the IQM Cortex server. It is not required for IQM Resonance.
             This can also be set in the IQM_AUTH_SERVER environment variable.
-        username (str): Username, if required by the IQM Cortex server.
+        username (str): Username, if required by the IQM Cortex server. It is not required for IQM Resonance.
             This can also be set in the IQM_AUTH_USERNAME environment variable.
         password (str): Password, if required by the IQM Cortex server.
-            This can also be set in the IQM_AUTH_PASSWORD environment variable.
+            This can also be set in the IQM_AUTH_PASSWORD environment variable. It is not required for IQM Resonance.
+        token: API token retrieved from IQM Resonance, not required for on-premise quantum computers.
+            Can also be set in the ``IQM_TOKEN`` environment variable.
     """
 
     def __init__(


### PR DESCRIPTION
This pull request updates the authentication process in IQMProvider and improves the user guide to better reflect the usage of IQM Resonance.

Changes:
* Updated IQMSampler to mention authentication option for IQM Resonance
* Mentioned the support for the token parameter in the User guide.
* Added separating headlines for IQM Resonance and on-prem QCs