### PR TITLE
switch order of route and decompose

### DIFF
--- a/examples/demo_iqm_execution.py
+++ b/examples/demo_iqm_execution.py
@@ -50,9 +50,9 @@ def demo_run_circuit() -> None:
 
     sampler = IQMSampler(os.environ['IQM_SERVER_URL'])
 
-    circuit_decomposed = sampler.device.decompose_circuit(circuit)
-    circuit_routed, _, _ = sampler.device.route_circuit(circuit_decomposed)
-    circuit = simplify_circuit(circuit_routed)
+    circuit_routed, _, _ = sampler.device.route_circuit(circuit)
+    circuit_decomposed = sampler.device.decompose_circuit(circuit_routed)
+    circuit = simplify_circuit(circuit_decomposed)
     print('\nTranspiled and routed circuit:\n')
     print(circuit)
     print('\n')


### PR DESCRIPTION
Currently, the example proposes to first run `decompose_circuit` followed by a `route_circuit`.
However, if the routing needs to introduce swap gates, these will stay in the circuit until execution where they lead to an error:
```
OperationNotSupportedError: <class 'cirq.ops.swap_gates.SwapPowGate'> not natively supported.
```

Therefore, the order of these two operations needs to be reversed.