### PR TITLE
Adding Reset Gate 

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -357,6 +357,29 @@ When executing a circuit that uses something other than the device qubits, you n
 as explained in the :ref:`routing` section above.
 
 
+Resetting Qubits
+-----------------
+
+The :class:`cirq.R` operation can be used to reset qubits to the :math:`|0\rangle` state.
+It is currently implemented as a (projective) measurement followed by a classically controlled X
+gate conditioned on the result, and is only available if the quantum computer supports
+classically controlled gates.
+
+.. code-block:: python
+
+    import cirq
+    q1 = cirq.NamedQubit('q1')
+    circuit = cirq.Circuit(cirq.X(q1), cirq.R(q1), cirq.measure(q1))
+    circuit
+
+::
+
+    q1: ───X───R───M───
+
+In the above example, the X gate prepares the qubit `q1` in a :math:`|1\rangle` state,
+and the reset then collapses it back into the :math:`|0\rangle` state.
+Executing the circuit should result in (mostly) zeros being measured.
+
 Authentication
 ^^^^^^^^^^^^^^
 

--- a/src/iqm/cirq_iqm/iqm_operation_mapping.py
+++ b/src/iqm/cirq_iqm/iqm_operation_mapping.py
@@ -11,10 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Logic for mapping Cirq Operations to the IQM transfer format.
-"""
+"""Logic for mapping Cirq Operations to the IQM transfer format."""
 from cirq import NamedQid
-from cirq.ops import CZPowGate, Gate, MeasurementGate, Operation, PhasedXPowGate, XPowGate, YPowGate, ResetChannel
+from cirq.ops import CZPowGate, Gate, MeasurementGate, Operation, PhasedXPowGate, ResetChannel, XPowGate, YPowGate
 
 from iqm.cirq_iqm.iqm_gates import IQMMoveGate
 from iqm.iqm_client import Instruction
@@ -27,7 +26,7 @@ _IQM_CIRQ_OP_MAP: dict[str, tuple[type[Gate], ...]] = {
     'cz': (CZPowGate,),
     'move': (IQMMoveGate,),
     'measure': (MeasurementGate,),
-    'reset': (ResetChannel,)
+    'reset': (ResetChannel,),
 }
 
 
@@ -125,9 +124,6 @@ def map_operation(operation: Operation) -> Instruction:
         )
 
     if isinstance(operation.gate, ResetChannel):
-        return Instruction(
-            name='reset',
-            qubits=tuple(qubits)
-        )
+        return Instruction(name='reset', qubits=tuple(qubits))
 
     raise OperationNotSupportedError(f'{type(operation.gate)} not natively supported.')

--- a/src/iqm/cirq_iqm/iqm_operation_mapping.py
+++ b/src/iqm/cirq_iqm/iqm_operation_mapping.py
@@ -14,7 +14,7 @@
 """Logic for mapping Cirq Operations to the IQM transfer format.
 """
 from cirq import NamedQid
-from cirq.ops import CZPowGate, Gate, MeasurementGate, Operation, PhasedXPowGate, XPowGate, YPowGate
+from cirq.ops import CZPowGate, Gate, MeasurementGate, Operation, PhasedXPowGate, XPowGate, YPowGate, ResetChannel
 
 from iqm.cirq_iqm.iqm_gates import IQMMoveGate
 from iqm.iqm_client import Instruction
@@ -27,6 +27,7 @@ _IQM_CIRQ_OP_MAP: dict[str, tuple[type[Gate], ...]] = {
     'cz': (CZPowGate,),
     'move': (IQMMoveGate,),
     'measure': (MeasurementGate,),
+    'reset': (ResetChannel,)
 }
 
 
@@ -121,6 +122,12 @@ def map_operation(operation: Operation) -> Instruction:
             name='move',
             qubits=tuple(qubits),
             args={},
+        )
+
+    if isinstance(operation.gate, ResetChannel):
+        return Instruction(
+            name='reset',
+            qubits=tuple(qubits)
         )
 
     raise OperationNotSupportedError(f'{type(operation.gate)} not natively supported.')

--- a/tests/test_iqm_operation_mapping.py
+++ b/tests/test_iqm_operation_mapping.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import cirq
-from cirq import CZPowGate, GateOperation, MeasurementGate, PhasedXPowGate, XPowGate, YPowGate, ZPowGate, ResetChannel
+from cirq import CZPowGate, GateOperation, MeasurementGate, PhasedXPowGate, ResetChannel, XPowGate, YPowGate, ZPowGate
 from mockito import mock
 import pytest
 

--- a/tests/test_iqm_operation_mapping.py
+++ b/tests/test_iqm_operation_mapping.py
@@ -115,7 +115,7 @@ def test_instruction_to_operation():
     assert isinstance(operation.gate, IQMMoveGate)
     assert operation.qubits == (cirq.NamedQubit('QB1'), cirq.NamedQid('COMP_R', dimension=2))
 
-    instruction = Instruction(name='reset', qubits=('QB1'))
+    instruction = Instruction(name='reset', qubits=('QB1',))
     operation = instruction_to_operation(instruction)
     assert isinstance(operation.gate, ResetChannel)
     assert operation.qubits == (cirq.NamedQubit('QB1'))

--- a/tests/test_iqm_operation_mapping.py
+++ b/tests/test_iqm_operation_mapping.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import cirq
-from cirq import CZPowGate, GateOperation, MeasurementGate, PhasedXPowGate, XPowGate, YPowGate, ZPowGate
+from cirq import CZPowGate, GateOperation, MeasurementGate, PhasedXPowGate, XPowGate, YPowGate, ZPowGate, ResetChannel
 from mockito import mock
 import pytest
 
@@ -114,3 +114,8 @@ def test_instruction_to_operation():
     operation = instruction_to_operation(instruction)
     assert isinstance(operation.gate, IQMMoveGate)
     assert operation.qubits == (cirq.NamedQubit('QB1'), cirq.NamedQid('COMP_R', dimension=2))
+
+    instruction = Instruction(name='reset', qubits=('QB1'))
+    operation = instruction_to_operation(instruction)
+    assert isinstance(operation.gate, ResetChannel)
+    assert operation.qubits == (cirq.NamedQubit('QB1'))


### PR DESCRIPTION
Related to this [PR](https://github.com/iqm-finland/cirq-on-iqm/pull/147). Pretty straightforward addition. 

At the moment, the  `map_operation` function in `iqm_operation_mapping.py` is failing Lint checks due to having too many return statements, but this is something that should be fixed once this [PR](https://github.com/iqm-finland/cirq-on-iqm/pull/147) gets merged. Everything else functions the same as with the other non-classically-controlled gates. 